### PR TITLE
fix: database name was still using malime

### DIFF
--- a/database/src/main/java/com/chesire/nekome/database/RoomDB.kt
+++ b/database/src/main/java/com/chesire/nekome/database/RoomDB.kt
@@ -46,9 +46,9 @@ abstract class RoomDB : RoomDatabase() {
         /**
          * Builds the database for usage.
          */
-        fun build(context: Context): RoomDB {
+        fun build(context: Context, databaseName: String = "nekome_database.db"): RoomDB {
             return Room
-                .databaseBuilder(context, RoomDB::class.java, "malime_database.db")
+                .databaseBuilder(context, RoomDB::class.java, databaseName)
                 .fallbackToDestructiveMigration()
                 .build()
         }


### PR DESCRIPTION
Update the database name to be nekome, and allow a custom name to be passed in if desired