### PR TITLE
refactor: bind listeners when creating viewholder

### DIFF
--- a/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsAdapter.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsAdapter.kt
@@ -25,12 +25,13 @@ class ResultsAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResultsViewHolder {
         return ResultsViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.item_result, parent, false)
-        )
+        ).apply {
+            bindListener(resultsListener)
+        }
     }
 
     override fun onBindViewHolder(holder: ResultsViewHolder, position: Int) {
         val data = getItem(position)
         holder.bind(data, allSeries?.any { it.id == data.id } ?: false)
-        holder.bindListener(resultsListener)
     }
 }

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesAdapter.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesAdapter.kt
@@ -67,13 +67,13 @@ class SeriesAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeriesViewHolder {
         return SeriesViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.adapter_item_series, parent, false)
-        )
+        ).apply {
+            bindListener(listener)
+        }
     }
 
-    override fun onBindViewHolder(holder: SeriesViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: SeriesViewHolder, position: Int) =
         holder.bind(getItem(position))
-        holder.bindListener(listener)
-    }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         when (key) {

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesViewHolder.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesViewHolder.kt
@@ -50,7 +50,12 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
      * Binds the [listener] to the view.
      */
     fun bindListener(listener: SeriesInteractionListener) {
-        itemView.setOnClickListener { listener.seriesSelected(adapterItemSeriesImage, seriesModel) }
+        containerView.setOnClickListener {
+            listener.seriesSelected(
+                adapterItemSeriesImage,
+                seriesModel
+            )
+        }
         adapterItemSeriesPlusOne.setOnClickListener {
             startUpdatingSeries()
             listener.onPlusOne(seriesModel) {


### PR DESCRIPTION
Instead of binding the listeners to the view whenever the data changes, it should be more efficient to just bind the listeners when the view is first created instead.