### PR TITLE
fix: licenses missing

### DIFF
--- a/app-settings/proguard-rules.pro
+++ b/app-settings/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Needed for the AboutLibraries library to work
+-keepclasseswithmembers class **.R$* {
+    public static final int define_*;
+}

--- a/app-settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
+++ b/app-settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
@@ -41,6 +41,7 @@ class OssFragment : DaggerFragment() {
         }
     }
 
+    @Suppress("SpreadOperator")
     private fun createLicensePage() = LibsBuilder()
         .withAutoDetect(false)
         .withLicenseShown(false)

--- a/app-settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
+++ b/app-settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
@@ -15,6 +15,22 @@ import dagger.android.support.DaggerFragment
  */
 @LogLifecykle
 class OssFragment : DaggerFragment() {
+    // Commented out libraries are pulled in automatically, because the library already includes the
+    // xml file required, or it is supplied manually. We only need to specify the libraries that the
+    // about libraries plugin provides.
+    private val includedLibraries = arrayOf(
+        // "AboutLibraries",
+        // "androidencryptionhelper",
+        "Dagger2",
+        "glide",
+        // "lifecyklelog",
+        // "liveevent",
+        "materialdialogs",
+        "moshi",
+        "Retrofit",
+        "Timber"
+    )
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -26,9 +42,12 @@ class OssFragment : DaggerFragment() {
     }
 
     private fun createLicensePage() = LibsBuilder()
+        .withAutoDetect(false)
         .withLicenseShown(false)
         .withLicenseDialog(true)
         .withAboutIconShown(false)
         .withVersionShown(false)
+        .withFields(R.string::class.java.fields)
+        .withLibraries(*includedLibraries)
         .supportFragment()
 }

--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -22,6 +22,3 @@
 
 # Keep the flags that Moshi needs to generate adapters
 -keep class com.chesire.nekome.core.flags.** { *; }
-
-# JSR 305 annotations are for embedding nullability information.
--dontwarn javax.annotation.**


### PR DESCRIPTION
ProGuard was stripping the licences out, it looks like even with the exclude for ProGuard it was having issues finding which libraries were being used, so switched to manually adding them