### PR TITLE
fix: bottom sheet theme is incorrect

### DIFF
--- a/app-series/src/main/res/layout/fragment_series_detail.xml
+++ b/app-series/src/main/res/layout/fragment_series_detail.xml
@@ -5,7 +5,8 @@
     android:layout_height="wrap_content"
     android:elevation="@dimen/bottom_sheet_elevation"
     android:focusable="true"
-    android:focusableInTouchMode="true">
+    android:focusableInTouchMode="true"
+    android:theme="@style/AppTheme">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
The bottom sheet colours are not defined in the application, it seems to be taking them from the
material design library. Change to set the theme on the bottom sheet layout so it always uses the
application theme as expected