### PR TITLE
chore: update bundler version to 2.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-android_lint (0.0.7)
+    danger-android_lint (0.0.8)
       danger-plugin-api (~> 1.0)
       oga
     danger-checkstyle_format (0.1.1)
@@ -209,4 +209,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   2.1.1
+   2.1.2


### PR DESCRIPTION
Update the version of bundler that builds the Gemfile.lock, update a danger item along with it