### PR TITLE
refactor: use by viewmodels

### DIFF
--- a/app-discover/src/main/java/com/chesire/nekome/app/discover/DiscoverFragment.kt
+++ b/app-discover/src/main/java/com/chesire/nekome/app/discover/DiscoverFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.chesire.lifecyklelog.LogLifecykle
@@ -23,9 +22,7 @@ import javax.inject.Inject
 class DiscoverFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<DiscoverViewModel>()
-    }
+    private val viewModel by viewModels<DiscoverViewModel> { viewModelFactory }
     private val animeTrendingAdapter = TrendingAdapter()
     private val mangaTrendingAdapter = TrendingAdapter()
 

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -37,9 +37,11 @@ dependencies {
     implementation project(path: ':series')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"

--- a/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileFragment.kt
+++ b/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.chesire.lifecyklelog.LogLifecykle
@@ -23,9 +22,7 @@ import javax.inject.Inject
 class ProfileFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<ProfileViewModel>()
-    }
+    private val viewModel by viewModels<ProfileViewModel> { viewModelFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
@@ -5,9 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.navigation.fragment.findNavController
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.core.extensions.hide
@@ -34,9 +33,7 @@ import javax.inject.Inject
 class SearchFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<SearchViewModel>()
-    }
+    private val viewModel by viewModels<SearchViewModel> { viewModelFactory }
     private val seriesType: SeriesType
         get() = when (seriesDetailStatusGroup.checkedChipId) {
             R.id.searchChipAnime -> SeriesType.Anime

--- a/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsFragment.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.chesire.lifecyklelog.LogLifecykle
@@ -27,9 +26,7 @@ import javax.inject.Inject
 class ResultsFragment : DaggerFragment(), ResultsListener {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<ResultsViewModel>()
-    }
+    private val viewModel by viewModels<ResultsViewModel> { viewModelFactory }
     private val args by navArgs<ResultsFragmentArgs>()
     private val resultsAdapter = ResultsAdapter(this)
 

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"

--- a/app-series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailSheetFragment.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailSheetFragment.kt
@@ -8,9 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.app.series.R
 import com.chesire.nekome.core.extensions.extraNotNull
@@ -42,13 +41,7 @@ import javax.inject.Inject
 class SeriesDetailSheetFragment : BottomSheetDialogFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory)
-            .get<SeriesDetailViewModel>()
-            .also { viewModel ->
-                viewModel.setModel(seriesModel)
-            }
-    }
+    private val viewModel by viewModels<SeriesDetailViewModel> { viewModelFactory }
     private val seriesModel by extraNotNull<SeriesModel>(MODEL_BUNDLE_ID, null)
 
     override fun onAttach(context: Context) {
@@ -64,6 +57,7 @@ class SeriesDetailSheetFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewModel.setModel(seriesModel)
         initializeView()
     }
 

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
@@ -8,9 +8,8 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.afollestad.materialdialogs.MaterialDialog
@@ -51,9 +50,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
      */
     protected abstract val seriesType: SeriesType
 
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<SeriesListViewModel>()
-    }
+    private val viewModel by viewModels<SeriesListViewModel> { viewModelFactory }
     private lateinit var seriesAdapter: SeriesAdapter
     private var seriesDetail: SeriesDetailSheetFragment? = null
 

--- a/app/src/main/java/com/chesire/nekome/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/Activity.kt
@@ -5,12 +5,11 @@ import android.os.Handler
 import android.os.Looper
 import android.view.MenuItem
 import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_LOCKED_CLOSED
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_UNLOCKED
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
@@ -41,9 +40,7 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
     lateinit var authCaster: AuthCaster
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<ActivityViewModel>()
-    }
+    private val viewModel by viewModels<ActivityViewModel> { viewModelFactory }
 
     private lateinit var appBarConfiguration: AppBarConfiguration
 

--- a/app/src/main/java/com/chesire/nekome/flow/login/details/DetailsFragment.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/login/details/DetailsFragment.kt
@@ -7,9 +7,8 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.StringRes
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.navigation.fragment.findNavController
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.R
@@ -39,12 +38,10 @@ import javax.inject.Inject
 @LogLifecykle
 class DetailsFragment : DaggerFragment() {
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<DetailsViewModel>()
-    }
-    @Inject
     lateinit var urlHandler: UrlHandler
+    @Inject
+    lateinit var viewModelFactory: ViewModelFactory
+    private val viewModel by viewModels<DetailsViewModel> { viewModelFactory }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/chesire/nekome/flow/login/syncing/SyncingFragment.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/login/syncing/SyncingFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.get
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.chesire.lifecyklelog.LogLifecykle
@@ -23,9 +22,7 @@ import javax.inject.Inject
 class SyncingFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
-    private val viewModel by lazy {
-        ViewModelProvider(this, viewModelFactory).get<SyncingViewModel>()
-    }
+    private val viewModel by viewModels<SyncingViewModel> { viewModelFactory }
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
Change how viewmodels are acquired in fragments to use the `by viewModels { }` syntax