### PR TITLE
refactor: change to use flow from database

### DIFF
--- a/account/build.gradle
+++ b/account/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation 'io.mockk:mockk:1.9.3'
     testImplementation 'junit:junit:4.13'

--- a/account/src/main/java/com/chesire/nekome/account/UserRepository.kt
+++ b/account/src/main/java/com/chesire/nekome/account/UserRepository.kt
@@ -17,7 +17,7 @@ class UserRepository(
     /**
      * Access the user information.
      */
-    val user = userDao.observe(Service.Kitsu)
+    val user = userDao.getUser(Service.Kitsu)
 
     /**
      * Updates the stored user in the database, data will be funneled to the [user].

--- a/account/src/test/java/com/chesire/nekome/account/UserRepositoryTests.kt
+++ b/account/src/test/java/com/chesire/nekome/account/UserRepositoryTests.kt
@@ -22,7 +22,7 @@ class UserRepositoryTests {
         val expected = mockk<UserModel>()
         val mockDao = mockk<UserDao> {
             coEvery { insert(expected) } just Runs
-            every { observe(Service.Kitsu) } returns mockk()
+            every { getUser(Service.Kitsu) } returns mockk()
         }
         val mockApi = mockk<UserApi> {
             coEvery { getUserDetails() } coAnswers { Resource.Success(expected) }
@@ -40,7 +40,7 @@ class UserRepositoryTests {
     fun `refreshUser returns the response from api`() = runBlocking {
         val expected = "error"
         val mockDao = mockk<UserDao> {
-            every { observe(Service.Kitsu) } returns mockk()
+            every { getUser(Service.Kitsu) } returns mockk()
         }
         val mockApi = mockk<UserApi> {
             coEvery { getUserDetails() } coAnswers { Resource.Error(expected) }
@@ -59,7 +59,7 @@ class UserRepositoryTests {
         val expected = 133
         val mockDao = mockk<UserDao> {
             coEvery { retrieveUserId(Service.Kitsu) } coAnswers { expected }
-            every { observe(Service.Kitsu) } returns mockk()
+            every { getUser(Service.Kitsu) } returns mockk()
         }
         val mockApi = mockk<UserApi>()
 

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"

--- a/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileViewModel.kt
+++ b/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.chesire.nekome.app.profile
 
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
@@ -17,10 +18,10 @@ class ProfileViewModel @Inject constructor(
     userRepository: UserRepository
 ) : ViewModel() {
     val user = userRepository.user
-    val anime = Transformations.map(seriesRepository.series) {
+    val anime = Transformations.map(seriesRepository.getSeries().asLiveData()) {
         createSeriesProgress(it.filter { it.type == SeriesType.Anime })
     }
-    val manga = Transformations.map(seriesRepository.series) {
+    val manga = Transformations.map(seriesRepository.getSeries().asLiveData()) {
         createSeriesProgress(it.filter { it.type == SeriesType.Manga })
     }
 

--- a/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileViewModel.kt
+++ b/app-profile/src/main/java/com/chesire/nekome/app/profile/ProfileViewModel.kt
@@ -17,7 +17,7 @@ class ProfileViewModel @Inject constructor(
     seriesRepository: SeriesRepository,
     userRepository: UserRepository
 ) : ViewModel() {
-    val user = userRepository.user
+    val user = userRepository.user.asLiveData()
     val anime = Transformations.map(seriesRepository.getSeries().asLiveData()) {
         createSeriesProgress(it.filter { it.type == SeriesType.Anime })
     }

--- a/app-profile/src/test/java/com/chesire/nekome/app/profile/ProfileViewModelTests.kt
+++ b/app-profile/src/test/java/com/chesire/nekome/app/profile/ProfileViewModelTests.kt
@@ -1,12 +1,10 @@
 package com.chesire.nekome.app.profile
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
-import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.series.SeriesRepository
 import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
 import com.chesire.nekome.testing.createSeriesModel
@@ -14,7 +12,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/app-profile/src/test/java/com/chesire/nekome/app/profile/ProfileViewModelTests.kt
+++ b/app-profile/src/test/java/com/chesire/nekome/app/profile/ProfileViewModelTests.kt
@@ -6,12 +6,16 @@ import androidx.lifecycle.Observer
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
+import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.series.SeriesRepository
+import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
 import com.chesire.nekome.testing.createSeriesModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -20,11 +24,13 @@ import org.junit.Test
 class ProfileViewModelTests {
     @get:Rule
     val taskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutineRule = CoroutinesMainDispatcherRule()
 
     @Test
     fun `anime gets updated with seriesRepository anime series`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(listOf(createSeriesModel(seriesType = SeriesType.Anime)))
+            every { getSeries() } returns flowOf(listOf(createSeriesModel(seriesType = SeriesType.Anime)))
         }
         val mockUserRepo = mockk<UserRepository> {
             every { user } returns mockk()
@@ -42,7 +48,7 @@ class ProfileViewModelTests {
     @Test
     fun `manga gets updated with seriesRepository manga series`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(listOf(createSeriesModel(seriesType = SeriesType.Manga)))
+            every { getSeries() } returns flowOf(listOf(createSeriesModel(seriesType = SeriesType.Manga)))
         }
         val mockUserRepo = mockk<UserRepository> {
             every { user } returns mockk()
@@ -60,7 +66,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected total items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
@@ -85,7 +91,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected current items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Current),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Planned),
@@ -110,7 +116,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected completed items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Completed),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Completed),
@@ -135,7 +141,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected onHold items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -160,7 +166,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected dropped items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -185,7 +191,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected planned items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
@@ -210,7 +216,7 @@ class ProfileViewModelTests {
     @Test
     fun `series has expected unknown items`() {
         val mockSeriesRepo = mockk<SeriesRepository> {
-            every { series } returns MutableLiveData(
+            every { getSeries() } returns flowOf(
                 listOf(
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.OnHold),
                     createSeriesModel(userSeriesStatus = UserSeriesStatus.Unknown),

--- a/app-search/build.gradle
+++ b/app-search/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"

--- a/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
@@ -1,6 +1,7 @@
 package com.chesire.nekome.app.search.results
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.flags.SeriesType
@@ -19,7 +20,7 @@ class ResultsViewModel @Inject constructor(
     private val authCaster: AuthCaster
 ) : ViewModel() {
 
-    val series = seriesRepo.series
+    val series = seriesRepo.getSeries().asLiveData()
 
     /**
      * Adds [newSeries] to the list of tracked series.

--- a/app-search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
+++ b/app-search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
@@ -29,7 +29,7 @@ class ResultsViewModelTests {
             } coAnswers {
                 Resource.Success(mockk())
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster>()
         val testObject = ResultsViewModel(mockRepo, mockCaster)
@@ -47,7 +47,7 @@ class ResultsViewModelTests {
             } coAnswers {
                 Resource.Success(mockk())
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster>()
         val testObject = ResultsViewModel(mockRepo, mockCaster)
@@ -65,7 +65,7 @@ class ResultsViewModelTests {
             } coAnswers {
                 Resource.Error("", Resource.Error.CouldNotRefresh)
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -85,7 +85,7 @@ class ResultsViewModelTests {
             } coAnswers {
                 Resource.Success(mockk())
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster>()
         val mockCallback = mockk<(Resource<SeriesModel>) -> Unit>()

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListViewModel.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListViewModel.kt
@@ -2,6 +2,7 @@ package com.chesire.nekome.app.series.list
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.extensions.postError
@@ -21,7 +22,7 @@ class SeriesListViewModel @Inject constructor(
     private val repo: SeriesRepository,
     private val authCaster: AuthCaster
 ) : ViewModel() {
-    val series = repo.series
+    val series = repo.getSeries().asLiveData()
     private val _deletionStatus = LiveEvent<AsyncState<SeriesModel, SeriesListDeleteError>>()
     val deletionStatus: LiveData<AsyncState<SeriesModel, SeriesListDeleteError>> = _deletionStatus
 

--- a/app-series/src/test/java/com/chesire/nekome/app/series/list/SeriesListViewModelTests.kt
+++ b/app-series/src/test/java/com/chesire/nekome/app/series/list/SeriesListViewModelTests.kt
@@ -35,7 +35,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 mockk()
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -53,7 +53,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.CouldNotRefresh)
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -74,7 +74,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.GenericError)
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -93,7 +93,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Success(mockk())
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
 
@@ -111,7 +111,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.CouldNotRefresh)
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -131,7 +131,7 @@ class SeriesListViewModelTests {
             } coAnswers {
                 Resource.Error("error", Resource.Error.GenericError)
             }
-            every { series } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockAuthCaster = mockk<AuthCaster>()
         val mockObserver = mockk<Observer<AsyncState<SeriesModel, SeriesListDeleteError>>>() {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"

--- a/app/src/main/java/com/chesire/nekome/flow/ActivityViewModel.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/ActivityViewModel.kt
@@ -1,6 +1,7 @@
 package com.chesire.nekome.flow
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.LogoutHandler
 import com.chesire.nekome.account.UserRepository
@@ -24,7 +25,7 @@ class ActivityViewModel @Inject constructor(
     /**
      * The currently logged in user.
      */
-    val user = userRepository.user
+    val user = userRepository.user.asLiveData()
 
     /**
      * Checks if the user is currently logged in.

--- a/app/src/main/java/com/chesire/nekome/flow/login/syncing/SyncingViewModel.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/login/syncing/SyncingViewModel.kt
@@ -3,6 +3,7 @@ package com.chesire.nekome.flow.login.syncing
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.extensions.postError
@@ -22,7 +23,7 @@ class SyncingViewModel @Inject constructor(
 ) : ViewModel() {
     private val _syncStatus = MutableLiveData<AsyncState<Any, Any>>()
     val syncStatus = _syncStatus
-    val avatarUrl = Transformations.map(userRepo.user) { it.avatar.largest?.url }
+    val avatarUrl = Transformations.map(userRepo.user.asLiveData()) { it.avatar.largest?.url }
 
     /**
      * Sets off the process for pulling down and storing the users series.

--- a/app/src/test/java/com/chesire/nekome/flow/login/syncing/SyncingViewModelTests.kt
+++ b/app/src/test/java/com/chesire/nekome/flow/login/syncing/SyncingViewModelTests.kt
@@ -1,14 +1,12 @@
 package com.chesire.nekome.flow.login.syncing
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.AsyncState
 import com.chesire.nekome.series.SeriesRepository
 import com.chesire.nekome.server.Resource
 import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
-import com.chesire.nekome.testing.createUserModel
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every

--- a/app/src/test/java/com/chesire/nekome/flow/login/syncing/SyncingViewModelTests.kt
+++ b/app/src/test/java/com/chesire/nekome/flow/login/syncing/SyncingViewModelTests.kt
@@ -34,7 +34,7 @@ class SyncingViewModelTests {
             coEvery { refreshManga() } coAnswers { Resource.Success(mockk()) }
         }
         val mockUser = mockk<UserRepository> {
-            every { user } returns MutableLiveData(createUserModel())
+            every { user } returns mockk()
         }
         val mockObserver = mockk<Observer<AsyncState<Any, Any>>> {
             every { onChanged(any()) } just Runs
@@ -54,7 +54,7 @@ class SyncingViewModelTests {
             coEvery { refreshManga() } coAnswers { Resource.Error("") }
         }
         val mockUser = mockk<UserRepository> {
-            every { user } returns MutableLiveData(createUserModel())
+            every { user } returns mockk()
         }
         val mockObserver = mockk<Observer<AsyncState<Any, Any>>> {
             every { onChanged(any()) } just Runs
@@ -74,7 +74,7 @@ class SyncingViewModelTests {
             coEvery { refreshManga() } coAnswers { Resource.Success(mockk()) }
         }
         val mockUser = mockk<UserRepository> {
-            every { user } returns MutableLiveData(createUserModel())
+            every { user } returns mockk()
         }
         val mockObserver = mockk<Observer<AsyncState<Any, Any>>> {
             every { onChanged(any()) } just Runs

--- a/database/src/main/java/com/chesire/nekome/database/dao/SeriesDao.kt
+++ b/database/src/main/java/com/chesire/nekome/database/dao/SeriesDao.kt
@@ -1,7 +1,6 @@
 package com.chesire.nekome.database.dao
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -9,6 +8,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.chesire.nekome.core.models.SeriesModel
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Dao to interact with series data.
@@ -16,13 +16,13 @@ import com.chesire.nekome.core.models.SeriesModel
 @Dao
 interface SeriesDao {
     /**
-     * Deletes the series [series].
+     * Deletes [series] from the dao.
      */
     @Delete
     suspend fun delete(series: SeriesModel)
 
     /**
-     * Inserts the series [series], replacing it if it already exists.
+     * Inserts [series], replacing it if it already exists.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(series: SeriesModel)
@@ -34,22 +34,22 @@ interface SeriesDao {
     suspend fun insert(series: List<SeriesModel>)
 
     /**
-     * Provides an observable for all [SeriesModel].
+     * Gets all the [SeriesModel], and subscribes to updates.
      */
     @Query("SELECT * FROM seriesmodel")
-    fun series(): LiveData<List<SeriesModel>>
+    fun getSeries(): Flow<List<SeriesModel>>
 
     /**
-     * Updates the series [series].
+     * Updates the [series].
      */
     @Update
     suspend fun update(series: SeriesModel)
 
     // This method only exists to allow easier testing of the SeriesDao.
     /**
-     * Retrieves all series.
+     * Retrieves all [SeriesModel].
      */
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     @Query("SELECT * FROM seriesmodel")
     suspend fun retrieve(): List<SeriesModel>
 }

--- a/database/src/main/java/com/chesire/nekome/database/dao/UserDao.kt
+++ b/database/src/main/java/com/chesire/nekome/database/dao/UserDao.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.database.dao
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -8,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.chesire.nekome.core.flags.Service
 import com.chesire.nekome.core.models.UserModel
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Dao to interact with user data.
@@ -48,5 +48,5 @@ interface UserDao {
      * Provides an observable for the type of [service].
      */
     @Query("SELECT * FROM usermodel WHERE service == :service")
-    fun observe(service: Service): LiveData<UserModel>
+    fun getUser(service: Service): Flow<UserModel>
 }

--- a/series/build.gradle
+++ b/series/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'io.mockk:mockk:1.9.3'

--- a/series/src/main/java/com/chesire/nekome/series/SeriesRepository.kt
+++ b/series/src/main/java/com/chesire/nekome/series/SeriesRepository.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.series
 
-import androidx.lifecycle.LiveData
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.SeriesModel
@@ -20,7 +19,7 @@ class SeriesRepository(
     /**
      * Observable list of all the users series (Anime + Manga).
      */
-    val series: LiveData<List<SeriesModel>> = seriesDao.series()
+    fun getSeries() = seriesDao.getSeries()
 
     /**
      * Adds the anime series with id [seriesId] to the users tracked list.

--- a/series/src/test/java/com/chesire/nekome/series/SeriesRepositoryTests.kt
+++ b/series/src/test/java/com/chesire/nekome/series/SeriesRepositoryTests.kt
@@ -1,7 +1,6 @@
 package com.chesire.nekome.series
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Observer
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.SeriesModel
@@ -14,7 +13,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -27,25 +25,11 @@ class SeriesRepositoryTests {
     val rule = InstantTaskExecutorRule()
 
     @Test
-    fun `series observes all the dao series`() {
-        val mockDao = mockk<SeriesDao> {
-            every { series() } returns mockk { every { observeForever(any()) } just Runs }
-        }
-        val mockApi = mockk<LibraryApi>()
-        val mockUser = mockk<UserRepository>()
-
-        val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
-        classUnderTest.series.observeForever(mockk<Observer<List<SeriesModel>>>())
-
-        verify { mockDao.series() }
-    }
-
-    @Test
     fun `addAnime onSuccess saves to dao`() = runBlocking {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -65,7 +49,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -85,7 +69,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<SeriesModel>("Error")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
@@ -105,7 +89,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -125,7 +109,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success<SeriesModel>(mockk())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -145,7 +129,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<SeriesModel>("Error")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<SeriesModel>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
@@ -167,7 +151,7 @@ class SeriesRepositoryTests {
         }
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns Resource.Success(Any())
@@ -187,7 +171,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Success(Any())
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
@@ -209,7 +193,7 @@ class SeriesRepositoryTests {
         val expected = Resource.Error<Any>("")
         val mockDao = mockk<SeriesDao> {
             coEvery { delete(any()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
@@ -231,7 +215,7 @@ class SeriesRepositoryTests {
         val response = Resource.Success(listOf<SeriesModel>())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<List<SeriesModel>>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveAnime(any()) } returns response
@@ -251,7 +235,7 @@ class SeriesRepositoryTests {
         val response = Resource.Error<List<SeriesModel>>("")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<List<SeriesModel>>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveAnime(any()) } returns response
@@ -271,7 +255,7 @@ class SeriesRepositoryTests {
         val response = Resource.Success(listOf<SeriesModel>())
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<List<SeriesModel>>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveManga(any()) } returns response
@@ -291,7 +275,7 @@ class SeriesRepositoryTests {
         val response = Resource.Error<List<SeriesModel>>("")
         val mockDao = mockk<SeriesDao> {
             coEvery { insert(any<List<SeriesModel>>()) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveManga(any()) } returns response
@@ -311,7 +295,7 @@ class SeriesRepositoryTests {
         val expected = mockk<SeriesModel>()
         val mockDao = mockk<SeriesDao> {
             coEvery { update(expected) } just Runs
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery {
@@ -331,7 +315,7 @@ class SeriesRepositoryTests {
     @Test
     fun `updateSeries on failure returns failure`() = runBlocking {
         val mockDao = mockk<SeriesDao> {
-            every { series() } returns mockk()
+            every { getSeries() } returns mockk()
         }
         val mockApi = mockk<LibraryApi> {
             coEvery {


### PR DESCRIPTION
It is recommended from various articles and from the Android dev summit (https://www.youtube.com/watch?v=B8ppnjGPAGE) that flow should be used for the non-ui layers.
Change moves from using LiveData in the Database and Repository to using Flow, and having just the ViewModel<->View using LiveData.

Further work will be done in the future to clean up the repository use.