### PR TITLE
chore: add library to add linting rules to project

### DIFF
--- a/account/build.gradle
+++ b/account/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/app-discover/build.gradle
+++ b/app-discover/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.google.android.material:material:$material_version"
     implementation "com.google.dagger:dagger:$dagger_version"
@@ -62,6 +64,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"
@@ -62,6 +64,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app-search/build.gradle
+++ b/app-search/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.github.hadilq.liveevent:liveevent:$liveevent_version"
     implementation "com.google.android.material:material:$material_version"
@@ -61,6 +63,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.github.hadilq.liveevent:liveevent:$liveevent_version"
     implementation "com.google.dagger:dagger:$dagger_version"
@@ -67,6 +69,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app-settings/build.gradle
+++ b/app-settings/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation "androidx.preference:preference:$preferences_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
@@ -53,6 +55,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app-timeline/build.gradle
+++ b/app-timeline/build.gradle
@@ -36,15 +36,17 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
 
     testImplementation 'junit:junit:4.13'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,8 @@ dependencies {
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.github.hadilq.liveevent:liveevent:$liveevent_version"
     implementation "com.google.android.material:material:$material_version"
@@ -117,8 +119,8 @@ dependencies {
     androidTestImplementation 'org.objenesis:objenesis:2.6'
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
-    kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
     kaptAndroidTest "com.google.dagger:dagger-android-processor:$dagger_version"
+    kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ ext {
     glide_version = "4.11.0"
     lifecycle_version = "2.2.0"
     lifecykle_version = "3.0.0"
+    lintrules_version = "1.1.3"
     liveevent_version = "1.0.1"
     material_version = "1.2.0-alpha04"
     materialdialog_version = "3.1.1"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.android.material:material:$material_version"
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.google.dagger:dagger-android:$dagger_version"

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.room:room-ktx:$room_version"
     implementation "androidx.room:room-runtime:$room_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/kitsu/build.gradle
+++ b/kitsu/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation 'com.github.talhahasanzia:android-encryption-helper:0.3.1'
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"

--- a/series/build.gradle
+++ b/series/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,4 +38,6 @@ dependencies {
     implementation project(path: ':core')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation project(path: ':core')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
+    implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation 'junit:junit:4.13'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 }


### PR DESCRIPTION
Add Chesire/LintRules to the project to give extra lint checks, it looks like some of them aren't
running in the app-* modules though strangely... the lexicographic ordering of Gradle dependencies
looks to have worked in app-timeline/build.gradle, but wasn't working in app-settings/build.gradle,
unsure why, the only thing I can think of is that one of them gets compiled into the main
application, the other does not currently. Unsure why this would have an effect though.