### PR TITLE
feat: set an initial type when reaching the search screen

### DIFF
--- a/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
@@ -34,6 +34,8 @@ class SearchFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
     private val viewModel by viewModels<SearchViewModel> { viewModelFactory }
+    @Inject
+    lateinit var searchPreferences: SearchPreferences
     private val seriesType: SeriesType
         get() = when (seriesDetailStatusGroup.checkedChipId) {
             R.id.searchChipAnime -> SeriesType.Anime
@@ -49,6 +51,7 @@ class SearchFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setInitialSeriesType()
         searchConfirmButton.setOnClickListener { submitSearch() }
         searchSeriesText.addTextChangedListener {
             searchSeriesLayout.error = null
@@ -56,8 +59,14 @@ class SearchFragment : DaggerFragment() {
         observeSearchResults()
     }
 
+    private fun setInitialSeriesType() {
+        val lastType = searchPreferences.lastSearchType
+        seriesDetailStatusGroup.check(if (lastType == 0) R.id.searchChipAnime else lastType)
+    }
+
     private fun submitSearch() {
         activity?.hideSystemKeyboard()
+        searchPreferences.lastSearchType = seriesDetailStatusGroup.checkedChipId
         viewModel.executeSearch(
             SearchData(
                 searchSeriesText.text.toString(),

--- a/app-search/src/main/java/com/chesire/nekome/app/search/SearchPreferences.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/SearchPreferences.kt
@@ -1,0 +1,22 @@
+package com.chesire.nekome.app.search
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import javax.inject.Inject
+
+/**
+ * Wrapper around [SharedPreferences] to store settings or items related to Search.
+ */
+@Suppress("UseDataClass")
+class SearchPreferences @Inject constructor(private val sharedPreferences: SharedPreferences) {
+    /**
+     * The last type that was selected on the Search screen.
+     */
+    var lastSearchType: Int
+        get() = sharedPreferences.getInt(LAST_SEARCH_TYPE, 0)
+        set(value) = sharedPreferences.edit { putInt(LAST_SEARCH_TYPE, value) }
+
+    companion object {
+        private const val LAST_SEARCH_TYPE = "preference.last_search_type"
+    }
+}

--- a/app-search/src/test/java/com/chesire/nekome/app/search/SearchPreferencesTests.kt
+++ b/app-search/src/test/java/com/chesire/nekome/app/search/SearchPreferencesTests.kt
@@ -1,0 +1,40 @@
+package com.chesire.nekome.app.search
+
+import android.content.SharedPreferences
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchPreferencesTests {
+    @Test
+    fun `lastSearchType returns expected value`() {
+        val expected = 9001
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getInt("preference.last_search_type", 0) } returns expected
+        }
+        val testObject = SearchPreferences(mockPreferences)
+
+        assertEquals(expected, testObject.lastSearchType)
+    }
+
+    @Test
+    fun `lastSearchType can set in value`() {
+        val expected = 9001
+        val mockEditor = mockk<SharedPreferences.Editor> {
+            every { apply() } just Runs
+            every { putInt("preference.last_search_type", expected) } returns this
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockEditor
+        }
+        val testObject = SearchPreferences(mockPreferences)
+
+        testObject.lastSearchType = expected
+
+        verify { mockEditor.putInt("preference.last_search_type", expected) }
+    }
+}


### PR DESCRIPTION
Set the Anime type when reaching the search screen. Once a choice has been commited it will save
this option in preferences for the next time the user reaches this screen