### PR TITLE
feat: allow choosing default new series state

### DIFF
--- a/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
@@ -3,9 +3,9 @@ package com.chesire.nekome.app.search.results
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.chesire.nekome.core.ApplicationSettings
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.series.SeriesRepository
 import com.chesire.nekome.server.Resource
@@ -17,7 +17,8 @@ import javax.inject.Inject
  */
 class ResultsViewModel @Inject constructor(
     private val seriesRepo: SeriesRepository,
-    private val authCaster: AuthCaster
+    private val authCaster: AuthCaster,
+    private val settings: ApplicationSettings
 ) : ViewModel() {
 
     val series = seriesRepo.getSeries().asLiveData()
@@ -32,11 +33,11 @@ class ResultsViewModel @Inject constructor(
         val response = when (newSeries.type) {
             SeriesType.Anime -> seriesRepo.addAnime(
                 newSeries.id,
-                UserSeriesStatus.Current
+                settings.defaultSeriesState
             )
             SeriesType.Manga -> seriesRepo.addManga(
                 newSeries.id,
-                UserSeriesStatus.Current
+                settings.defaultSeriesState
             )
             else -> error("Unknown SeriesType: ${newSeries.type}")
         }

--- a/app-search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
+++ b/app-search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
@@ -1,7 +1,9 @@
 package com.chesire.nekome.app.search.results
 
+import com.chesire.nekome.core.ApplicationSettings
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.flags.SeriesType
+import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.series.SeriesRepository
 import com.chesire.nekome.server.Resource
@@ -32,7 +34,10 @@ class ResultsViewModelTests {
             every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster>()
-        val testObject = ResultsViewModel(mockRepo, mockCaster)
+        val mockSettings = mockk<ApplicationSettings> {
+            every { defaultSeriesState } returns UserSeriesStatus.Current
+        }
+        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
 
         testObject.trackNewSeries(createSeriesModel(seriesType = SeriesType.Anime)) {}
 
@@ -50,7 +55,10 @@ class ResultsViewModelTests {
             every { getSeries() } returns mockk()
         }
         val mockCaster = mockk<AuthCaster>()
-        val testObject = ResultsViewModel(mockRepo, mockCaster)
+        val mockSettings = mockk<ApplicationSettings> {
+            every { defaultSeriesState } returns UserSeriesStatus.Current
+        }
+        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
 
         testObject.trackNewSeries(createSeriesModel(seriesType = SeriesType.Manga)) {}
 
@@ -70,7 +78,10 @@ class ResultsViewModelTests {
         val mockCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
         }
-        val testObject = ResultsViewModel(mockRepo, mockCaster)
+        val mockSettings = mockk<ApplicationSettings> {
+            every { defaultSeriesState } returns UserSeriesStatus.Current
+        }
+        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
 
         testObject.trackNewSeries(createSeriesModel(seriesType = SeriesType.Manga)) {}
 
@@ -89,7 +100,10 @@ class ResultsViewModelTests {
         }
         val mockCaster = mockk<AuthCaster>()
         val mockCallback = mockk<(Resource<SeriesModel>) -> Unit>()
-        val testObject = ResultsViewModel(mockRepo, mockCaster)
+        val mockSettings = mockk<ApplicationSettings> {
+            every { defaultSeriesState } returns UserSeriesStatus.Current
+        }
+        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
 
         testObject.trackNewSeries(createSeriesModel(seriesType = SeriesType.Anime), mockCallback)
 

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/DialogHandler.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/DialogHandler.kt
@@ -20,15 +20,12 @@ class DialogHandler @Inject constructor(private val preferences: SeriesPreferenc
      * Shows the filter dialog, allowing the user to choose how to filter their series.
      */
     fun showFilterDialog(context: Context, lifecycleOwner: LifecycleOwner) {
-        val filterOptionMap = UserSeriesStatus
-            .values()
-            .filterNot { it == UserSeriesStatus.Unknown }
-            .associate { context.getString(it.stringId) to it.index }
+        val filterOptionMap = UserSeriesStatus.getValueMap(context)
 
         MaterialDialog(context).show {
             title(R.string.filter_dialog_title)
             listItemsMultiChoice(
-                items = filterOptionMap.keys.toList(),
+                items = filterOptionMap.values.toList(),
                 initialSelection = preferences.filterPreference.filter { it.value }.keys.toIntArray()
             ) { _, _, items: List<CharSequence> ->
                 preferences.filterPreference = createFilterMap(
@@ -43,11 +40,11 @@ class DialogHandler @Inject constructor(private val preferences: SeriesPreferenc
     }
 
     private fun createFilterMap(
-        allItems: Map<String, Int>,
+        allItems: Map<Int, String>,
         chosenItems: List<String>
     ) = mutableMapOf<Int, Boolean>().apply {
         allItems.forEach { entry ->
-            this[entry.value] = chosenItems.contains(entry.key)
+            this[entry.key] = chosenItems.contains(entry.value)
         }
     }
 

--- a/app-settings/src/main/java/com/chesire/nekome/app/settings/SettingsFragment.kt
+++ b/app-settings/src/main/java/com/chesire/nekome/app/settings/SettingsFragment.kt
@@ -4,9 +4,11 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.navigation.fragment.findNavController
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.chesire.lifecyklelog.LogLifecykle
+import com.chesire.nekome.core.flags.UserSeriesStatus
 import timber.log.Timber
 
 /**
@@ -17,12 +19,20 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private lateinit var keyPrivacyPolicy: String
     private lateinit var keyLicenses: String
     private lateinit var keyGithub: String
+    private lateinit var keyDefaultSeriesState: String
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
         keyPrivacyPolicy = getString(R.string.key_privacy_policy)
         keyLicenses = getString(R.string.key_licenses)
         keyGithub = getString(R.string.key_github)
+        keyDefaultSeriesState = getString(R.string.key_default_series_state)
+
+        findPreference<ListPreference>(keyDefaultSeriesState)?.let { pref ->
+            val userSeriesMap = UserSeriesStatus.getValueMap(requireContext())
+            pref.entries = userSeriesMap.values.toTypedArray()
+            pref.entryValues = userSeriesMap.keys.map { it.toString() }.toTypedArray()
+        }
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {

--- a/app-settings/src/main/res/xml/preferences.xml
+++ b/app-settings/src/main/res/xml/preferences.xml
@@ -3,8 +3,8 @@
     <PreferenceCategory android:title="@string/settings_general_category">
         <ListPreference
             android:key="@string/key_default_series_state"
-            android:summary="@string/settings_default_series_state_summary"
-            android:title="@string/settings_default_series_state_title" />
+            android:summary="@string/settings_default_series_status_summary"
+            android:title="@string/settings_default_series_status_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_about_category">

--- a/app-settings/src/main/res/xml/preferences.xml
+++ b/app-settings/src/main/res/xml/preferences.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory android:title="@string/settings_general_category">
+        <ListPreference
+            android:key="@string/key_default_series_state"
+            android:summary="@string/settings_default_series_state_summary"
+            android:title="@string/settings_default_series_state_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/settings_about_category">
         <Preference
             android:summary="@string/version"

--- a/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
+++ b/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
@@ -11,6 +11,7 @@ import javax.inject.Inject
  * Interact with the settings of the application, provides methods to get the user chosen values.
  * These values must be set from the settings fragment within the app-Settings module.
  */
+@Suppress("UseDataClass")
 @Reusable
 class ApplicationSettings @Inject constructor(
     context: Context,

--- a/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
+++ b/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
@@ -1,0 +1,35 @@
+package com.chesire.nekome.core
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.chesire.nekome.core.flags.UserSeriesStatus
+import dagger.Reusable
+import javax.inject.Inject
+
+/**
+ * Interact with the settings of the application, provides methods to get the user chosen values.
+ * These values must be set from the settings fragment within the app-Settings module.
+ */
+@Reusable
+class ApplicationSettings @Inject constructor(
+    context: Context,
+    private val preferences: SharedPreferences
+) {
+
+    private val _defaultSeriesState = context.getString(R.string.key_default_series_state)
+
+    /**
+     * Gets the default [UserSeriesStatus] a series should start in when a user begins tracking it.
+     */
+    val defaultSeriesState: UserSeriesStatus
+        get() = UserSeriesStatus.getFromIndex(
+            requireNotNull(
+                preferences.getString(
+                    _defaultSeriesState,
+                    UserSeriesStatus.Current.index.toString()
+                )
+            ) {
+                "Preferences defaultSeriesState returned null, with supplied default value"
+            }
+        )
+}

--- a/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
+++ b/core/src/main/java/com/chesire/nekome/core/ApplicationSettings.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.chesire.nekome.core.flags.UserSeriesStatus
-import dagger.Reusable
 import javax.inject.Inject
 
 /**
@@ -12,7 +11,6 @@ import javax.inject.Inject
  * These values must be set from the settings fragment within the app-Settings module.
  */
 @Suppress("UseDataClass")
-@Reusable
 class ApplicationSettings @Inject constructor(
     context: Context,
     private val preferences: SharedPreferences

--- a/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
+++ b/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
@@ -1,6 +1,9 @@
 package com.chesire.nekome.core.flags
 
 import android.content.Context
+import android.view.ViewDebug
+import androidx.annotation.IntDef
+import androidx.annotation.IntRange
 import androidx.annotation.StringRes
 import com.chesire.nekome.core.R
 
@@ -23,5 +26,16 @@ enum class UserSeriesStatus(val index: Int, @StringRes val stringId: Int) {
         fun getValueMap(context: Context) = values()
             .filterNot { it == Unknown }
             .associate { it.index to context.getString(it.stringId) }
+
+        /**
+         * Gets the [UserSeriesStatus] from a given [index], the [index] should be the index field
+         * in the the enum class, but as a string. If this is null or cannot be found then [Unknown]
+         * will be returned.
+         */
+        fun getFromIndex(index: String): UserSeriesStatus {
+            return index.toIntOrNull()?.let { intIndex ->
+                values().find { it.index == intIndex } ?: Unknown
+            } ?: Unknown
+        }
     }
 }

--- a/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
+++ b/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
@@ -1,5 +1,6 @@
 package com.chesire.nekome.core.flags
 
+import android.content.Context
 import androidx.annotation.StringRes
 import com.chesire.nekome.core.R
 
@@ -12,5 +13,15 @@ enum class UserSeriesStatus(val index: Int, @StringRes val stringId: Int) {
     Completed(1, R.string.filter_by_completed),
     OnHold(2, R.string.filter_by_on_hold),
     Dropped(3, R.string.filter_by_dropped),
-    Planned(4, R.string.filter_by_planned)
+    Planned(4, R.string.filter_by_planned);
+
+    companion object {
+        /**
+         * Gets a map of [index] to the string acquired from the [stringId].
+         * This call will ignore the [Unknown] value as it should not be displayed to the user.
+         */
+        fun getValueMap(context: Context) = values()
+            .filterNot { it == Unknown }
+            .associate { it.index to context.getString(it.stringId) }
+    }
 }

--- a/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
+++ b/core/src/main/java/com/chesire/nekome/core/flags/UserSeriesStatus.kt
@@ -1,9 +1,6 @@
 package com.chesire.nekome.core.flags
 
 import android.content.Context
-import android.view.ViewDebug
-import androidx.annotation.IntDef
-import androidx.annotation.IntRange
 import androidx.annotation.StringRes
 import com.chesire.nekome.core.R
 

--- a/core/src/main/res/values/keys.xml
+++ b/core/src/main/res/values/keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="key_default_series_state" translatable="false">keyDefaultSeriesState</string>
+</resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -90,8 +90,8 @@
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_github">GitHub</string>
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
-    <string name="settings_default_series_state_title">Default Series State</string>
-    <string name="settings_default_series_state_summary">Default state a series will be in when it is tracked</string>
+    <string name="settings_default_series_state_title">Default Series Status</string>
+    <string name="settings_default_series_state_summary">Status a newly tracked series will start in</string>
 
     <string name="discover_trending_anime">Trending Anime</string>
     <string name="discover_trending_manga">Trending Manga</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -90,8 +90,8 @@
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_github">GitHub</string>
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
-    <string name="settings_default_series_state_title">Default Series Status</string>
-    <string name="settings_default_series_state_summary">Status a newly tracked series will start in</string>
+    <string name="settings_default_series_status_title">Default Series Status</string>
+    <string name="settings_default_series_status_summary">Status a newly tracked series will start in</string>
 
     <string name="discover_trending_anime">Trending Anime</string>
     <string name="discover_trending_manga">Trending Manga</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_github">GitHub</string>
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
+    <string name="settings_default_series_state_title">Default Series State</string>
+    <string name="settings_default_series_state_summary">Default state a series will be in when it is tracked</string>
 
     <string name="discover_trending_anime">Trending Anime</string>
     <string name="discover_trending_manga">Trending Manga</string>

--- a/core/src/test/java/com/chesire/nekome/core/ApplicationSettingsTests.kt
+++ b/core/src/test/java/com/chesire/nekome/core/ApplicationSettingsTests.kt
@@ -1,0 +1,25 @@
+package com.chesire.nekome.core
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.chesire.nekome.core.flags.UserSeriesStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApplicationSettingsTests {
+    private val mockContext = mockk<Context> {
+        every { getString(R.string.key_default_series_state) } returns "key_default_series_state"
+    }
+
+    @Test
+    fun `can get defaultSeriesState`() {
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getString("key_default_series_state", "0") } returns "2"
+        }
+        val testObject = ApplicationSettings(mockContext, mockPreferences)
+
+        assertEquals(UserSeriesStatus.OnHold, testObject.defaultSeriesState)
+    }
+}

--- a/core/src/test/java/com/chesire/nekome/core/ApplicationSettingsTests.kt
+++ b/core/src/test/java/com/chesire/nekome/core/ApplicationSettingsTests.kt
@@ -3,8 +3,11 @@ package com.chesire.nekome.core
 import android.content.Context
 import android.content.SharedPreferences
 import com.chesire.nekome.core.flags.UserSeriesStatus
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -21,5 +24,39 @@ class ApplicationSettingsTests {
         val testObject = ApplicationSettings(mockContext, mockPreferences)
 
         assertEquals(UserSeriesStatus.OnHold, testObject.defaultSeriesState)
+    }
+
+    @Test
+    fun `defaultSeriesState with Unknown value resets preference value to Current`() {
+        val mockEditor = mockk<SharedPreferences.Editor> {
+            every { putString("key_default_series_state", "0") } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getString("key_default_series_state", "0") } returns "-1"
+            every { edit() } returns mockEditor
+        }
+        val testObject = ApplicationSettings(mockContext, mockPreferences)
+
+        testObject.defaultSeriesState
+
+        verify { mockEditor.putString("key_default_series_state", "0") }
+    }
+
+    @Test
+    fun `defaultSeriesState with Unknown value returns Current`() {
+        val mockEditor = mockk<SharedPreferences.Editor> {
+            every { putString("key_default_series_state", "0") } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getString("key_default_series_state", "0") } returns "-1"
+            every { edit() } returns mockEditor
+        }
+        val testObject = ApplicationSettings(mockContext, mockPreferences)
+
+        val result = testObject.defaultSeriesState
+
+        assertEquals(UserSeriesStatus.Current, result)
     }
 }

--- a/core/src/test/java/com/chesire/nekome/core/flags/UserSeriesStatusTests.kt
+++ b/core/src/test/java/com/chesire/nekome/core/flags/UserSeriesStatusTests.kt
@@ -1,0 +1,107 @@
+package com.chesire.nekome.core.flags
+
+import android.content.Context
+import com.chesire.nekome.core.R
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class UserSeriesStatusTests {
+    @Test
+    fun `getValueMap returns expected map`() {
+        val mockContext = mockk<Context> {
+            every { getString(R.string.filter_by_current) } returns "current"
+            every { getString(R.string.filter_by_completed) } returns "completed"
+            every { getString(R.string.filter_by_on_hold) } returns "onhold"
+            every { getString(R.string.filter_by_dropped) } returns "dropped"
+            every { getString(R.string.filter_by_planned) } returns "planned"
+        }
+        val map = UserSeriesStatus.getValueMap(mockContext)
+
+        assertEquals("current", map.getValue(0))
+        assertEquals("completed", map.getValue(1))
+        assertEquals("onhold", map.getValue(2))
+        assertEquals("dropped", map.getValue(3))
+        assertEquals("planned", map.getValue(4))
+    }
+
+    @Test
+    fun `getValueMap ignores the Unknown value`() {
+        val mockContext = mockk<Context> {
+            every { getString(R.string.filter_by_current) } returns "current"
+            every { getString(R.string.filter_by_completed) } returns "completed"
+            every { getString(R.string.filter_by_on_hold) } returns "onhold"
+            every { getString(R.string.filter_by_dropped) } returns "dropped"
+            every { getString(R.string.filter_by_planned) } returns "planned"
+        }
+        val map = UserSeriesStatus.getValueMap(mockContext)
+
+        assertFalse(UserSeriesStatus.values().count() == map.count())
+    }
+
+    @Test
+    fun `getFromIndex with non int value returns Unknown value`() {
+        assertEquals(
+            UserSeriesStatus.Unknown,
+            UserSeriesStatus.getFromIndex("not an int")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with out of range value returns Unknown value`() {
+        assertEquals(
+            UserSeriesStatus.Unknown,
+            UserSeriesStatus.getFromIndex("99")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '-1' value returns Unknown value`() {
+        assertEquals(
+            UserSeriesStatus.Unknown,
+            UserSeriesStatus.getFromIndex("-1")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '0' value returns Current value`() {
+        assertEquals(
+            UserSeriesStatus.Current,
+            UserSeriesStatus.getFromIndex("0")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '1' value returns Completed value`() {
+        assertEquals(
+            UserSeriesStatus.Completed,
+            UserSeriesStatus.getFromIndex("1")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '2' value returns OnHold value`() {
+        assertEquals(
+            UserSeriesStatus.OnHold,
+            UserSeriesStatus.getFromIndex("2")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '3' value returns Dropped value`() {
+        assertEquals(
+            UserSeriesStatus.Dropped,
+            UserSeriesStatus.getFromIndex("3")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '4' value returns Planned value`() {
+        assertEquals(
+            UserSeriesStatus.Planned,
+            UserSeriesStatus.getFromIndex("4")
+        )
+    }
+}


### PR DESCRIPTION
Allow a user to choose what the default state will be when a user begins tracking a new series.
This introduces an ApplicationSettings class that will be the top level class to forward on any application settings to the rest of the application.