### PR TITLE
fix: auth token not refreshing

### DIFF
--- a/app/src/androidTest/java/com/chesire/nekome/harness/FakeAuthApi.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/harness/FakeAuthApi.kt
@@ -8,6 +8,10 @@ open class FakeAuthApi : AuthApi {
         TODO("not implemented")
     }
 
+    override suspend fun refresh(): Resource<Any> {
+        TODO("not implemented")
+    }
+
     override suspend fun clearAuth() {
         TODO("not implemented")
     }

--- a/app/src/main/java/com/chesire/nekome/App.kt
+++ b/app/src/main/java/com/chesire/nekome/App.kt
@@ -34,6 +34,7 @@ class App : DaggerApplication() {
             startStrictMode()
         }
 
+        workerQueue.enqueueAuthRefresh()
         workerQueue.enqueueSeriesRefresh()
         workerQueue.enqueueUserRefresh()
     }

--- a/app/src/main/java/com/chesire/nekome/injection/components/AppComponent.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/components/AppComponent.kt
@@ -14,6 +14,7 @@ import com.chesire.nekome.injection.modules.SeriesModule
 import com.chesire.nekome.injection.modules.ServerModule
 import com.chesire.nekome.injection.modules.UrlModule
 import com.chesire.nekome.injection.modules.WorkerModule
+import com.chesire.nekome.services.RefreshAuthWorker
 import com.chesire.nekome.services.RefreshSeriesWorker
 import com.chesire.nekome.services.RefreshUserWorker
 import dagger.BindsInstance
@@ -38,8 +39,8 @@ import javax.inject.Singleton
         KitsuModule::class,
         SeriesModule::class,
         ServerModule::class,
-        ViewModelModule::class,
         UrlModule::class,
+        ViewModelModule::class,
         WorkerModule::class
     ]
 )
@@ -60,6 +61,11 @@ interface AppComponent : AndroidInjector<App> {
          */
         fun build(): AppComponent
     }
+
+    /**
+     * Provides Dagger injection into the [RefreshAuthWorker].
+     */
+    fun inject(worker: RefreshAuthWorker)
 
     /**
      * Provides Dagger injection into the [RefreshSeriesWorker].

--- a/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
+++ b/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
@@ -6,34 +6,38 @@ import androidx.work.WorkerParameters
 import com.chesire.nekome.App
 import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.server.Resource
+import com.chesire.nekome.server.api.AuthApi
 import timber.log.Timber
 import javax.inject.Inject
 
+
 /**
- * Worker object that handles updating the information for a user.
+ * Worker object that handles updating a users authenticated state.
  *
  * When scheduled to run it will send a request to the [userRepo] to try to refresh the current
- * user data.
+ * user.
  */
-class RefreshUserWorker(
+class RefreshAuthWorker(
     appContext: Context,
     workerParams: WorkerParameters
 ) : CoroutineWorker(appContext, workerParams) {
 
     @Inject
     lateinit var userRepo: UserRepository
+    @Inject
+    lateinit var auth: AuthApi
 
     init {
         // For now setup in the init block
         // dagger currently doesn't support androidInjection for workers
-        Timber.i("Initializing the RefreshUserWorker")
+        Timber.i("Initializing the RefreshAuthWorker")
         if (appContext is App) {
             appContext.daggerComponent.inject(this)
         }
     }
 
     override suspend fun doWork(): Result {
-        Timber.i("doWork RefreshUserWorker")
+        Timber.i("doWork RefreshAuthWorker")
 
         if (userRepo.retrieveUserId() == null) {
             Timber.i("doWork no userId found, so cancelling")
@@ -41,7 +45,7 @@ class RefreshUserWorker(
         }
 
         Timber.i("doWork userId found, beginning to refresh")
-        return if (userRepo.refreshUser() is Resource.Error) {
+        return if (auth.refresh() is Resource.Error) {
             Result.retry()
         } else {
             Result.success()

--- a/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
+++ b/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
@@ -10,7 +10,6 @@ import com.chesire.nekome.server.api.AuthApi
 import timber.log.Timber
 import javax.inject.Inject
 
-
 /**
  * Worker object that handles updating a users authenticated state.
  *

--- a/app/src/main/java/com/chesire/nekome/services/WorkerQueue.kt
+++ b/app/src/main/java/com/chesire/nekome/services/WorkerQueue.kt
@@ -8,6 +8,8 @@ import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
+private const val AUTH_REFRESH_TAG = "AuthRefresh"
+private const val AUTH_UNIQUE_NAME = "AuthSync"
 private const val SERIES_REFRESH_TAG = "SeriesRefresh"
 private const val SERIES_UNIQUE_NAME = "SeriesSync"
 private const val USER_REFRESH_TAG = "UserRefresh"
@@ -20,6 +22,22 @@ class WorkerQueue @Inject constructor(private val workManager: WorkManager) {
     private val constraints = Constraints.Builder()
         .setRequiredNetworkType(NetworkType.CONNECTED)
         .build()
+
+    /**
+     * Starts up the worker to perform auth refreshing.
+     */
+    fun enqueueAuthRefresh() {
+        val request = PeriodicWorkRequestBuilder<RefreshAuthWorker>(7, TimeUnit.DAYS)
+            .setConstraints(constraints)
+            .addTag(AUTH_REFRESH_TAG)
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            AUTH_UNIQUE_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
 
     /**
      * Starts up the worker to perform series refreshing.

--- a/app/src/main/java/com/chesire/nekome/services/WorkerQueue.kt
+++ b/app/src/main/java/com/chesire/nekome/services/WorkerQueue.kt
@@ -70,12 +70,4 @@ class WorkerQueue @Inject constructor(private val workManager: WorkManager) {
             request
         )
     }
-
-    /**
-     * Cancels any queued workers.
-     */
-    fun cancelQueued() {
-        workManager.cancelUniqueWork(SERIES_UNIQUE_NAME)
-        workManager.cancelUniqueWork(USER_UNIQUE_NAME)
-    }
 }

--- a/app/src/test/java/com/chesire/nekome/services/RefreshAuthWorkerTests.kt
+++ b/app/src/test/java/com/chesire/nekome/services/RefreshAuthWorkerTests.kt
@@ -1,0 +1,91 @@
+package com.chesire.nekome.services
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.chesire.nekome.account.UserRepository
+import com.chesire.nekome.server.Resource
+import com.chesire.nekome.server.api.AuthApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RefreshAuthWorkerTests {
+    @Test
+    fun `doWork null userId returns Result#success early`() = runBlocking {
+        val mockContext = mockk<Context>()
+        val mockParams = mockk<WorkerParameters> {
+            every { taskExecutor } returns mockk {
+                every { backgroundExecutor } returns mockk()
+            }
+        }
+        val mockUserRepo = mockk<UserRepository> {
+            coEvery { retrieveUserId() } coAnswers { null }
+        }
+
+        RefreshAuthWorker(mockContext, mockParams).run {
+            userRepo = mockUserRepo
+
+            val result = doWork()
+
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify(exactly = 0) { userRepo.refreshUser() }
+        }
+    }
+
+    @Test
+    fun `doWork refresh successful returns Result#success`() = runBlocking {
+        val mockContext = mockk<Context>()
+        val mockParams = mockk<WorkerParameters> {
+            every { taskExecutor } returns mockk {
+                every { backgroundExecutor } returns mockk()
+            }
+        }
+        val mockUserRepo = mockk<UserRepository> {
+            coEvery { retrieveUserId() } coAnswers { 1 }
+        }
+        val mockAuthApi = mockk<AuthApi> {
+            coEvery { refresh() } coAnswers { Resource.Success(mockk()) }
+        }
+
+        RefreshAuthWorker(mockContext, mockParams).run {
+            userRepo = mockUserRepo
+            auth = mockAuthApi
+
+            val result = doWork()
+
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify(exactly = 1) { mockAuthApi.refresh() }
+        }
+    }
+
+    @Test
+    fun `doWork refresh failure returns Result#retry`() = runBlocking {
+        val mockContext = mockk<Context>()
+        val mockParams = mockk<WorkerParameters> {
+            every { taskExecutor } returns mockk {
+                every { backgroundExecutor } returns mockk()
+            }
+        }
+        val mockUserRepo = mockk<UserRepository> {
+            coEvery { retrieveUserId() } coAnswers { 1 }
+        }
+        val mockAuthApi = mockk<AuthApi> {
+            coEvery { refresh() } coAnswers { Resource.Error("") }
+        }
+
+        RefreshAuthWorker(mockContext, mockParams).run {
+            userRepo = mockUserRepo
+            auth = mockAuthApi
+
+            val result = doWork()
+
+            assertEquals(ListenableWorker.Result.retry(), result)
+            coVerify(exactly = 1) { mockAuthApi.refresh() }
+        }
+    }
+}

--- a/app/src/test/java/com/chesire/nekome/services/WorkerQueueTests.kt
+++ b/app/src/test/java/com/chesire/nekome/services/WorkerQueueTests.kt
@@ -9,6 +9,31 @@ import org.junit.Test
 
 class WorkerQueueTests {
     @Test
+    fun `enqueueAuthRefresh enqueues the request on the manager`() {
+        val mockWorkManager = mockk<WorkManager> {
+            every {
+                enqueueUniquePeriodicWork(
+                    "AuthSync",
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    any()
+                )
+            } returns mockk()
+        }
+
+        WorkerQueue(mockWorkManager).run {
+            enqueueAuthRefresh()
+
+            verify {
+                mockWorkManager.enqueueUniquePeriodicWork(
+                    "AuthSync",
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    any()
+                )
+            }
+        }
+    }
+
+    @Test
     fun `enqueueSeriesRefresh enqueues the request on the manager`() {
         val mockWorkManager = mockk<WorkManager> {
             every {
@@ -55,32 +80,6 @@ class WorkerQueueTests {
                     any()
                 )
             }
-        }
-    }
-
-    @Test
-    fun `cancelEnqueued cancels the SeriesRefresh worker`() {
-        val mockWorkManager = mockk<WorkManager> {
-            every { cancelUniqueWork("SeriesSync") } returns mockk()
-            every { cancelUniqueWork("UserSync") } returns mockk()
-        }
-
-        WorkerQueue(mockWorkManager).run {
-            cancelQueued()
-            verify { mockWorkManager.cancelUniqueWork("SeriesSync") }
-        }
-    }
-
-    @Test
-    fun `cancelEnqueued cancels the UserRefresh worker`() {
-        val mockWorkManager = mockk<WorkManager> {
-            every { cancelUniqueWork("SeriesSync") } returns mockk()
-            every { cancelUniqueWork("UserSync") } returns mockk()
-        }
-
-        WorkerQueue(mockWorkManager).run {
-            cancelQueued()
-            verify { mockWorkManager.cancelUniqueWork("UserSync") }
         }
     }
 }

--- a/kitsu/src/main/java/com/chesire/nekome/kitsu/api/auth/KitsuAuth.kt
+++ b/kitsu/src/main/java/com/chesire/nekome/kitsu/api/auth/KitsuAuth.kt
@@ -1,9 +1,9 @@
 package com.chesire.nekome.kitsu.api.auth
 
-import com.chesire.nekome.server.Resource
-import com.chesire.nekome.server.api.AuthApi
 import com.chesire.nekome.kitsu.AuthProvider
 import com.chesire.nekome.kitsu.parse
+import com.chesire.nekome.server.Resource
+import com.chesire.nekome.server.api.AuthApi
 import javax.inject.Inject
 
 /**
@@ -18,16 +18,36 @@ class KitsuAuth @Inject constructor(
         return try {
             when (val response = authService.loginAsync(LoginRequest(username, password)).parse()) {
                 is Resource.Success -> {
-                    authProvider.apply {
-                        accessToken = response.data.accessToken
-                        refreshToken = response.data.refreshToken
-                    }
+                    saveTokens(response.data)
                     Resource.Success(Any())
                 }
                 is Resource.Error -> Resource.Error(response.msg, response.code)
             }
         } catch (ex: Exception) {
             ex.parse()
+        }
+    }
+
+    override suspend fun refresh(): Resource<Any> {
+        return try {
+            when (val response = authService.refreshAccessTokenAsync(
+                RefreshTokenRequest(authProvider.refreshToken)
+            ).parse()) {
+                is Resource.Success -> {
+                    saveTokens(response.data)
+                    Resource.Success(Any())
+                }
+                is Resource.Error -> Resource.Error(response.msg, response.code)
+            }
+        } catch (ex: Exception) {
+            ex.parse()
+        }
+    }
+
+    private fun saveTokens(loginResponse: LoginResponse) {
+        authProvider.apply {
+            accessToken = loginResponse.accessToken
+            refreshToken = loginResponse.refreshToken
         }
     }
 

--- a/server/src/main/java/com/chesire/nekome/server/api/AuthApi.kt
+++ b/server/src/main/java/com/chesire/nekome/server/api/AuthApi.kt
@@ -12,6 +12,12 @@ interface AuthApi {
     suspend fun login(username: String, password: String): Resource<Any>
 
     /**
+     * Sends a request to refresh any currently stored tokens. The result is returned in a standard
+     * [Resource].
+     */
+    suspend fun refresh(): Resource<Any>
+
+    /**
      * Clears the auth details out.
      */
     suspend fun clearAuth()


### PR DESCRIPTION
The auth token was not being refreshed by the background worker, so if a user did not update any series within the time for the tokens to expire (I think 30days?) then it would no longer work.
This was failing due to an assumption that getting the user details with a filter of `self` would require a user to be logged in, but it did not, so instead a new worker was added that will go out and refresh the auth token every 7 days to ensure it remains valid.