### PR TITLE
chore: cleanup gradle files

### DIFF
--- a/account/build.gradle
+++ b/account/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -15,7 +15,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -28,11 +28,11 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
-    implementation project(path: ':database')
-    implementation project(path: ':server')
+    implementation project(path: ":core")
+    implementation project(path: ":database")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -42,7 +42,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 }

--- a/account/build.gradle
+++ b/account/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-discover/build.gradle
+++ b/app-discover/build.gradle
@@ -13,7 +13,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-discover/build.gradle
+++ b/app-discover/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
+apply plugin: "androidx.navigation.safeargs.kotlin"
 
 android {
     compileSdkVersion 29
@@ -17,7 +17,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -29,11 +29,11 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
-    implementation project(path: ':series')
-    implementation project(path: ':server')
+    implementation project(path: ":core")
+    implementation project(path: ":series")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -55,10 +55,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
 
-    testImplementation project(path: ':testing')
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation project(path: ":testing")
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"

--- a/app-discover/build.gradle
+++ b/app-discover/build.gradle
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -12,7 +12,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-profile/build.gradle
+++ b/app-profile/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -16,7 +16,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -28,11 +28,11 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':account')
-    implementation project(path: ':core')
-    implementation project(path: ':series')
+    implementation project(path: ":account")
+    implementation project(path: ":core")
+    implementation project(path: ":series")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -52,14 +52,14 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     implementation "com.google.android.material:material:$material_version"
 
-    testImplementation project(path: ':testing')
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation project(path: ":testing")
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"

--- a/app-search/build.gradle
+++ b/app-search/build.gradle
@@ -13,7 +13,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-search/build.gradle
+++ b/app-search/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
+apply plugin: "androidx.navigation.safeargs.kotlin"
 
 android {
     compileSdkVersion 29
@@ -17,7 +17,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -29,11 +29,11 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
-    implementation project(path: ':series')
-    implementation project(path: ':server')
+    implementation project(path: ":core")
+    implementation project(path: ":series")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -54,10 +54,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
 
-    testImplementation project(path: ':testing')
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation project(path: ":testing")
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"

--- a/app-search/build.gradle
+++ b/app-search/build.gradle
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -16,7 +16,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -28,12 +28,12 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':account')
-    implementation project(path: ':core')
-    implementation project(path: ':series')
-    implementation project(path: ':server')
+    implementation project(path: ":account")
+    implementation project(path: ":core")
+    implementation project(path: ":series")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -58,14 +58,14 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
 
-    testImplementation project(path: ':testing')
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation project(path: ":testing")
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -12,7 +12,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-series/build.gradle
+++ b/app-series/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-settings/build.gradle
+++ b/app-settings/build.gradle
@@ -13,7 +13,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-settings/build.gradle
+++ b/app-settings/build.gradle
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-settings/build.gradle
+++ b/app-settings/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
+apply plugin: "androidx.navigation.safeargs.kotlin"
 
 android {
     compileSdkVersion 29
@@ -17,7 +17,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -26,13 +26,13 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
+    implementation project(path: ":core")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation 'androidx.browser:browser:1.2.0'
+    implementation "androidx.browser:browser:1.2.0"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
@@ -46,12 +46,12 @@ dependencies {
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
-    implementation 'com.mikepenz:aboutlibraries:7.1.0'
+    implementation "com.mikepenz:aboutlibraries:7.1.0"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:4.13"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
 
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"

--- a/app-timeline/build.gradle
+++ b/app-timeline/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -16,7 +16,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -40,10 +40,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:4.13"
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
 
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"

--- a/app-timeline/build.gradle
+++ b/app-timeline/build.gradle
@@ -12,7 +12,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/app-timeline/build.gradle
+++ b/app-timeline/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
+apply plugin: "androidx.navigation.safeargs.kotlin"
 
 android {
     compileSdkVersion 29
@@ -21,15 +21,15 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
         debug {
             applicationIdSuffix = ".debug"
-            versionNameSuffix '-DEBUG'
+            versionNameSuffix "-DEBUG"
             testCoverageEnabled !project.hasProperty("skipCoverage")
         }
         buildTypes.each {
-            it.resValue('string', 'version', defaultConfig.versionName)
+            it.resValue("string", "version", defaultConfig.versionName)
         }
     }
     androidExtensions {
@@ -43,25 +43,25 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
-        exclude 'META-INF/library-core_release.kotlin_module'
+        exclude "META-INF/library-core_release.kotlin_module"
     }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':account')
-    implementation project(path: ':app-discover')
-    implementation project(path: ':app-profile')
-    implementation project(path: ':app-search')
-    implementation project(path: ':app-series')
-    implementation project(path: ':app-settings')
-    implementation project(path: ':app-timeline')
-    implementation project(path: ':core')
-    implementation project(path: ':database')
-    implementation project(path: ':kitsu')
-    implementation project(path: ':series')
-    implementation project(path: ':server')
+    implementation project(path: ":account")
+    implementation project(path: ":app-discover")
+    implementation project(path: ":app-profile")
+    implementation project(path: ":app-search")
+    implementation project(path: ":app-series")
+    implementation project(path: ":app-settings")
+    implementation project(path: ":app-timeline")
+    implementation project(path: ":core")
+    implementation project(path: ":database")
+    implementation project(path: ":kitsu")
+    implementation project(path: ":series")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -75,7 +75,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"
-    implementation 'androidx.work:work-runtime-ktx:2.3.1'
+    implementation "androidx.work:work-runtime-ktx:2.3.1"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"
@@ -90,33 +90,33 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.3.1'
+    implementation "com.squareup.okhttp3:logging-interceptor:4.3.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.2"
 
-    testImplementation project(path: ':testing')
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation project(path: ":testing")
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation project(path: ':testing')
-    androidTestImplementation 'androidx.arch.core:core-testing:2.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
-    // androidTestImplementation 'androidx.work:work-testing:2.0.1'
-    androidTestImplementation('com.schibsted.spain:barista:3.2.0') {
-        exclude group: 'com.android.support'
-        exclude group: 'org.jetbrains.kotlin'
+    androidTestImplementation project(path: ":testing")
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test:rules:1.2.0"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:3.2.0"
+    // androidTestImplementation "androidx.work:work-testing:2.0.1"
+    androidTestImplementation("com.schibsted.spain:barista:3.2.0") {
+        exclude group: "com.android.support"
+        exclude group: "org.jetbrains.kotlin"
     }
     // Fixes issue with mockk 1.9.3 https://github.com/mockk/mockk/issues/281
-    androidTestImplementation('io.mockk:mockk-android:1.9.3') { exclude module: 'objenesis' }
+    androidTestImplementation("io.mockk:mockk-android:1.9.3") { exclude module: "objenesis" }
     //noinspection GradleDependency
-    androidTestImplementation 'org.objenesis:objenesis:2.6'
+    androidTestImplementation "org.objenesis:objenesis:2.6"
 
     kapt "com.github.bumptech.glide:compiler:$glide_version"
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,6 @@ android {
         testInstrumentationRunner "com.chesire.nekome.TestRunner"
         resConfigs "en"
     }
-
     buildTypes {
         release {
             minifyEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,10 +104,10 @@ dependencies {
 
     androidTestImplementation project(path: ":testing")
     androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.1"
-    androidTestImplementation "androidx.test:rules:1.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-intents:3.2.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test:rules:1.2.0"
     // androidTestImplementation "androidx.work:work-testing:2.0.1"
     androidTestImplementation("com.schibsted.spain:barista:3.2.0") {
         exclude group: "com.android.support"

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
-    ext.jacoco_version = '0.8.5'
-    ext.kotlin_version = '1.3.61'
-    ext.nav_version = '2.2.1'
+    ext.jacoco_version = "0.8.5"
+    ext.kotlin_version = "1.3.61"
+    ext.nav_version = "2.2.1"
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -24,7 +24,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
+        maven { url "https://jitpack.io" }
     }
 }
 
@@ -91,13 +91,13 @@ ext {
 ext.appVersion = {
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags', '--always'
+        commandLine "git", "describe", "--tags", "--always"
         standardOutput = stdout
     }
 
     def longTag = stdout.toString().trim()
-    if (longTag.contains('-')) {
-        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    if (longTag.contains("-")) {
+        return longTag.substring(longTag.indexOf("/") + 1, longTag.indexOf("-"))
     } else {
         return longTag
     }

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,8 @@ ext.appVersion = {
     }
 
     def longTag = stdout.toString().trim()
-    if (longTag.contains("-")) {
-        return longTag.substring(longTag.indexOf("/") + 1, longTag.indexOf("-"))
+    if (longTag.contains('-')) {
+        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
     } else {
         return longTag
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -11,12 +11,12 @@ android {
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'proguard-rules.pro'
+        consumerProguardFiles "proguard-rules.pro"
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -32,12 +32,12 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation 'androidx.browser:browser:1.2.0'
+    implementation "androidx.browser:browser:1.2.0"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
@@ -50,10 +50,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
 
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,6 @@ android {
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "proguard-rules.pro"
     }
     buildTypes {
         release {

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -19,7 +19,6 @@ android {
             }
         }
     }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -23,7 +23,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -39,9 +39,9 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
+    implementation project(path: ":core")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -54,15 +54,15 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:4.13"
 
     androidTestImplementation "androidx.room:room-testing:$room_version"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test:rules:1.2.0"
     // Fixes issue with mockk 1.9.3 https://github.com/mockk/mockk/issues/281
-    androidTestImplementation('io.mockk:mockk-android:1.9.3') { exclude module: 'objenesis' }
+    androidTestImplementation("io.mockk:mockk-android:1.9.3") { exclude module: "objenesis" }
     //noinspection GradleDependency
-    androidTestImplementation 'org.objenesis:objenesis:2.6'
+    androidTestImplementation "org.objenesis:objenesis:2.6"
 
     kapt "androidx.room:room-compiler:$room_version"
 }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -21,10 +21,10 @@ task jacocoTestReport(
     def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: coverageExcludes)
     def mainSrc = "$project.projectDir/src/main/java"
 
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = fileTree(dir: project.buildDir, includes: [
+    getSourceDirectories().setFrom(files([mainSrc]))
+    getClassDirectories().setFrom(files([debugTree]))
+    getExecutionData().setFrom(fileTree(dir: project.buildDir, includes: [
             "jacoco/testDebugUnitTest.exec",
             "outputs/code-coverage/connected/*coverage.ec"
-    ])
+    ]))
 }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'jacoco'
+apply plugin: "jacoco"
 
 jacoco {
     toolVersion = "$jacoco_version"
@@ -10,7 +10,7 @@ tasks.withType(Test) {
 
 task jacocoTestReport(
         type: JacocoReport,
-        group: 'verification'
+        group: "verification"
 ) {
     reports {
         xml.enabled = true
@@ -24,7 +24,7 @@ task jacocoTestReport(
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
     executionData = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec',
-            'outputs/code-coverage/connected/*coverage.ec'
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/connected/*coverage.ec"
     ])
 }

--- a/kitsu/build.gradle
+++ b/kitsu/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -15,7 +15,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -31,17 +31,17 @@ dependencies {
     ext {
         retrofit_version = "2.7.1"
     }
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
-    implementation project(path: ':server')
+    implementation project(path: ":core")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
-    implementation 'com.github.talhahasanzia:android-encryption-helper:0.3.1'
+    implementation "com.github.talhahasanzia:android-encryption-helper:0.3.1"
     implementation "com.google.dagger:dagger:$dagger_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     api "com.squareup.retrofit2:converter-moshi:$retrofit_version"
@@ -49,9 +49,9 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.6'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation "com.squareup.okhttp3:mockwebserver:3.14.6"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
 
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"

--- a/kitsu/build.gradle
+++ b/kitsu/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/series/build.gradle
+++ b/series/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/series/build.gradle
+++ b/series/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -15,7 +15,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     kotlinOptions {
@@ -28,12 +28,12 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':account')
-    implementation project(path: ':core')
-    implementation project(path: ':database')
-    implementation project(path: ':server')
+    implementation project(path: ":account")
+    implementation project(path: ":core")
+    implementation project(path: ":database")
+    implementation project(path: ":server")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -43,8 +43,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'io.mockk:mockk:1.9.3'
-    testImplementation 'junit:junit:4.13'
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
 
 android {
     compileSdkVersion 29
@@ -15,7 +15,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
     androidExtensions {
@@ -31,9 +31,9 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
+    implementation project(path: ":core")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,6 +1,6 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
 
 android {
     compileSdkVersion 29
@@ -15,19 +15,19 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ':core')
+    implementation project(path: ":core")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
-    implementation 'junit:junit:4.13'
+    implementation "junit:junit:4.13"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -8,8 +8,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -11,7 +11,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Cleanup the Gradle files to be more consistent across the board, removing the versionName/versionCode where it wasn't required, and making the files more in line with how the Kotlin DSL would want them to be, so it's easier to change in the future.