### PR TITLE
fix: restore details state on config change

### DIFF
--- a/app/src/main/java/com/chesire/nekome/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/Activity.kt
@@ -55,12 +55,11 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
 
         authCaster.subscribeToAuthError(this)
 
-        // This is needed or the DetailsFragment will be recreated on configuration change
-        if (savedInstanceState == null) {
-            if (!viewModel.userLoggedIn) {
-                findNavController(R.id.activityNavigation)
-                    .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
-            }
+        // savedInstanceState check is needed or the DetailsFragment will be recreated
+        // on configuration change
+        if (savedInstanceState == null && !viewModel.userLoggedIn) {
+            findNavController(R.id.activityNavigation)
+                .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
         }
     }
 

--- a/app/src/main/java/com/chesire/nekome/flow/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/Activity.kt
@@ -38,6 +38,7 @@ import javax.inject.Inject
 class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
     @Inject
     lateinit var authCaster: AuthCaster
+
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
     private val viewModel by viewModels<ActivityViewModel> { viewModelFactory }
@@ -53,9 +54,13 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener {
         observeViewModel()
 
         authCaster.subscribeToAuthError(this)
-        if (!viewModel.userLoggedIn) {
-            findNavController(R.id.activityNavigation)
-                .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
+
+        // This is needed or the DetailsFragment will be recreated on configuration change
+        if (savedInstanceState == null) {
+            if (!viewModel.userLoggedIn) {
+                findNavController(R.id.activityNavigation)
+                    .navigate(OverviewNavGraphDirections.globalToDetailsFragment())
+            }
         }
     }
 

--- a/app/src/main/java/com/chesire/nekome/flow/login/details/DetailsFragment.kt
+++ b/app/src/main/java/com/chesire/nekome/flow/login/details/DetailsFragment.kt
@@ -29,8 +29,14 @@ import javax.inject.Inject
  */
 @LogLifecykle
 class DetailsFragment : DaggerFragment() {
+    companion object {
+        private const val BUNDLE_USERNAME = "bundle_username"
+        private const val BUNDLE_PASSWORD = "bundle_password"
+    }
+
     @Inject
     lateinit var urlHandler: UrlHandler
+
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
     private val viewModel by viewModels<DetailsViewModel> { viewModelFactory }
@@ -45,6 +51,11 @@ class DetailsFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        savedInstanceState?.let { state ->
+            binding.usernameText.setText(state.getString(BUNDLE_USERNAME))
+            binding.passwordText.setText(state.getString(BUNDLE_PASSWORD))
+        }
 
         binding.usernameText.addTextChangedListener { binding.usernameLayout.error = "" }
         binding.passwordText.addTextChangedListener { binding.passwordLayout.error = "" }
@@ -63,6 +74,15 @@ class DetailsFragment : DaggerFragment() {
 
         setupLinks()
         viewModel.loginStatus.observe(viewLifecycleOwner, Observer { loginStatusChanged(it) })
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        _binding?.let { binding ->
+            outState.putString(BUNDLE_USERNAME, binding.usernameText.text.toString())
+            outState.putString(BUNDLE_PASSWORD, binding.passwordText.text.toString())
+        }
     }
 
     private fun setupLinks() {


### PR DESCRIPTION
Ensure that the login details are stored through configuration change by using `onSaveInstanceState`, from what i've read the text should have been stored by using IDs on the view elements, but it doesn't look like it was working in this instance.