### PR TITLE
fix: cleanup memory leaks

### DIFF
--- a/app-series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailViewModel.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailViewModel.kt
@@ -29,8 +29,8 @@ class SeriesDetailViewModel @Inject constructor(
     lateinit var mutableModel: MutableSeriesModel
 
     private val _updatingStatus = LiveEvent<AsyncState<MutableSeriesModel, SeriesDetailError>>()
-    val updatingStatus: LiveData<AsyncState<MutableSeriesModel, SeriesDetailError>> =
-        _updatingStatus
+    val updatingStatus: LiveData<AsyncState<MutableSeriesModel, SeriesDetailError>>
+        get() = _updatingStatus
 
     /**
      * Sets the model object into the ViewModel.

--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
@@ -40,8 +40,10 @@ import javax.inject.Inject
 abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
+
     @Inject
     lateinit var dialogHandler: DialogHandler
+
     @Inject
     lateinit var seriesPreferences: SeriesPreferences
 
@@ -54,7 +56,6 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     private val binding get() = requireNotNull(_binding) { "Binding not set" }
     private val viewModel by viewModels<SeriesListViewModel> { viewModelFactory }
     private lateinit var seriesAdapter: SeriesAdapter
-    private var seriesDetail: SeriesDetailSheetFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -120,13 +121,9 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     override fun seriesSelected(imageView: ImageView, model: SeriesModel) {
         Timber.i("seriesSelected called with Model ${model.slug}")
 
-        if (seriesDetail?.isVisible == true) {
-            Timber.w("Attempt to open series detail while already visible")
-        } else {
-            seriesDetail = SeriesDetailSheetFragment.newInstance(model).also {
-                it.show(childFragmentManager, SeriesDetailSheetFragment.TAG)
-            }
-        }
+        SeriesDetailSheetFragment
+            .newInstance(model)
+            .show(parentFragmentManager, SeriesDetailSheetFragment.TAG)
     }
 
     override fun onPlusOne(model: SeriesModel, callback: () -> Unit) {


### PR DESCRIPTION
Clean up a memory leak around the series detail fragment, the bottom sheet dialog instance was being leaked. Looks like retaining the instance / using a `childFragmentManager` as opposed to the `parentFragmentManager` was causing it to be leaked.

This solves one of the leaks, there are still two more that need to be investigated.

Fixes part of #123 