### PR TITLE
revert: chore: remove unused proguard line

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles "proguard-rules.pro"
     }
     buildTypes {
         release {


### PR DESCRIPTION
This reverts commit 4e19fc94daf79e5c722531b4238ed01d60cc910a.
The consumerProguardRules were needed for anything consuming the core library
to ensure the proguard rules were set up correctly. Without this proguard file
the application will crash when trying to perform various operations.