### PR TITLE
fix: login failing after proguard has run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath "com.android.tools.build:gradle:3.5.3"
+        classpath "com.android.tools.build:gradle:3.6.1"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,15 @@ buildscript {
     ext.kotlin_version = "1.3.70"
     ext.nav_version = "2.2.1"
     repositories {
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
         google()
         jcenter()
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+        classpath "com.android.tools:r8:1.6.75" // Must be before the Gradle Plugin for Android.
         classpath "com.android.tools.build:gradle:3.6.1"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath "com.android.tools.build:gradle:3.6.1"
+        classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 19 20:51:42 BST 2019
+#Sun Mar 15 14:01:37 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 25 20:20:58 GMT 2020
+#Fri Apr 19 20:51:42 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
+++ b/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
@@ -40,6 +40,6 @@ internal fun <T> Exception.parse(): Resource.Error<T> {
     return if (this is UnknownHostException) {
         Resource.Error("Could not reach service", 503)
     } else {
-        Resource.Error("Unknown error encountered", 400)
+        Resource.Error(toString(), 400)
     }
 }

--- a/kitsu/src/main/java/com/chesire/nekome/kitsu/api/auth/KitsuAuth.kt
+++ b/kitsu/src/main/java/com/chesire/nekome/kitsu/api/auth/KitsuAuth.kt
@@ -17,7 +17,7 @@ class KitsuAuth @Inject constructor(
 ) : AuthApi {
     override suspend fun login(username: String, password: String): Resource<Any> {
         return try {
-            return parseResponse(authService.loginAsync(LoginRequest(username, password)))
+            parseResponse(authService.loginAsync(LoginRequest(username, password)))
         } catch (ex: Exception) {
             ex.parse()
         }
@@ -25,7 +25,7 @@ class KitsuAuth @Inject constructor(
 
     override suspend fun refresh(): Resource<Any> {
         return try {
-            return parseResponse(
+            parseResponse(
                 authService.refreshAccessTokenAsync(
                     RefreshTokenRequest(authProvider.refreshToken)
                 )

--- a/kitsu/src/test/java/com/chesire/nekome/kitsu/ResponseParsingTests.kt
+++ b/kitsu/src/test/java/com/chesire/nekome/kitsu/ResponseParsingTests.kt
@@ -78,7 +78,7 @@ class ResponseParsingTests {
     fun `Exception#parse handles generic exception`() {
         // use some random exception to simulate
         val exception = NullPointerException().parse<Any>()
-        assertEquals("Unknown error encountered", exception.msg)
+        assertEquals("java.lang.NullPointerException", exception.msg)
         assertEquals(400, exception.code)
     }
 }


### PR DESCRIPTION
Trying to login to account after proguard had run on the application was constantly failing.
It looks like this was an issue with R8 being quite aggressive, it will be fixed in a later version of R8 pushed with the Gradle plugin. For now force the version of R8 to be a later one with the fix.