### PR TITLE
fix: remove memory leak due to leaking view

### DIFF
--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
@@ -55,7 +55,6 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     private var _binding: FragmentSeriesListBinding? = null
     private val binding get() = requireNotNull(_binding) { "Binding not set" }
     private val viewModel by viewModels<SeriesListViewModel> { viewModelFactory }
-    private lateinit var seriesAdapter: SeriesAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -71,7 +70,7 @@ abstract class SeriesListFragment : DaggerFragment(), SeriesInteractionListener 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        seriesAdapter = SeriesAdapter(this, seriesPreferences)
+        val seriesAdapter = SeriesAdapter(this, seriesPreferences)
         binding.listContent.apply {
             adapter = seriesAdapter
             layoutManager = LinearLayoutManager(requireContext())


### PR DESCRIPTION
Remove the field for the adapter since it isn't needed across the class, its only needed in the
livedata callbacks from the viewmodel which are setup in the onViewCreated anyway, this removes the
memory leak that was occurring in the series list

fixes #123