### PR TITLE
fix: search not auto selecting type

### DIFF
--- a/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
@@ -29,6 +29,7 @@ class SearchFragment : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
     private val viewModel by viewModels<SearchViewModel> { viewModelFactory }
+
     @Inject
     lateinit var searchPreferences: SearchPreferences
     private val seriesType: SeriesType
@@ -54,22 +55,29 @@ class SearchFragment : DaggerFragment() {
         binding.searchText.addTextChangedListener {
             binding.searchTextLayout.error = null
         }
+        binding.searchChipGroup.setOnCheckedChangeListener { _, checkedId ->
+            val type = when (checkedId) {
+                R.id.searchChipAnime -> SeriesType.Anime
+                R.id.searchChipManga -> SeriesType.Manga
+                else -> SeriesType.Unknown
+            }
+            searchPreferences.lastSearchType = type.id
+        }
         observeSearchResults()
     }
 
     private fun setInitialSeriesType() {
-        val lastType = searchPreferences.lastSearchType
-        binding.searchChipGroup.check(if (lastType == 0) R.id.searchChipAnime else lastType)
+        val chipId = when (SeriesType.forId(searchPreferences.lastSearchType)) {
+            SeriesType.Manga -> R.id.searchChipManga
+            else -> R.id.searchChipAnime
+        }
+        binding.searchChipGroup.check(chipId)
     }
 
     private fun submitSearch() {
         activity?.hideSystemKeyboard()
-        searchPreferences.lastSearchType = binding.searchChipGroup.checkedChipId
         viewModel.executeSearch(
-            SearchData(
-                binding.searchText.text.toString(),
-                seriesType
-            )
+            SearchData(binding.searchText.text.toString(), seriesType)
         )
     }
 

--- a/app-search/src/main/java/com/chesire/nekome/app/search/SearchPreferences.kt
+++ b/app-search/src/main/java/com/chesire/nekome/app/search/SearchPreferences.kt
@@ -2,6 +2,7 @@ package com.chesire.nekome.app.search
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.chesire.nekome.core.flags.SeriesType
 import javax.inject.Inject
 
 /**
@@ -10,10 +11,10 @@ import javax.inject.Inject
 @Suppress("UseDataClass")
 class SearchPreferences @Inject constructor(private val sharedPreferences: SharedPreferences) {
     /**
-     * The last type that was selected on the Search screen.
+     * The last type that was selected on the Search screen, defaults to Unknown if none found.
      */
     var lastSearchType: Int
-        get() = sharedPreferences.getInt(LAST_SEARCH_TYPE, 0)
+        get() = sharedPreferences.getInt(LAST_SEARCH_TYPE, SeriesType.Unknown.id)
         set(value) = sharedPreferences.edit { putInt(LAST_SEARCH_TYPE, value) }
 
     companion object {

--- a/app-search/src/main/res/layout/fragment_search.xml
+++ b/app-search/src/main/res/layout/fragment_search.xml
@@ -40,6 +40,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchTextLayout"
+        app:selectionRequired="true"
         app:singleSelection="true">
 
         <com.google.android.material.chip.Chip

--- a/app-search/src/test/java/com/chesire/nekome/app/search/SearchPreferencesTests.kt
+++ b/app-search/src/test/java/com/chesire/nekome/app/search/SearchPreferencesTests.kt
@@ -14,7 +14,7 @@ class SearchPreferencesTests {
     fun `lastSearchType returns expected value`() {
         val expected = 9001
         val mockPreferences = mockk<SharedPreferences> {
-            every { getInt("preference.last_search_type", 0) } returns expected
+            every { getInt("preference.last_search_type", -1) } returns expected
         }
         val testObject = SearchPreferences(mockPreferences)
 

--- a/core/src/main/java/com/chesire/nekome/core/flags/SeriesType.kt
+++ b/core/src/main/java/com/chesire/nekome/core/flags/SeriesType.kt
@@ -3,8 +3,15 @@ package com.chesire.nekome.core.flags
 /**
  * All possible types of a series.
  */
-enum class SeriesType {
-    Unknown,
-    Anime,
-    Manga
+enum class SeriesType(val id: Int) {
+    Unknown(-1),
+    Anime(0),
+    Manga(1);
+
+    companion object {
+        /**
+         * Gets the series typed based on its id.
+         */
+        fun forId(typeId: Int): SeriesType = values().find { it.id == typeId } ?: Unknown
+    }
 }

--- a/core/src/test/java/com/chesire/nekome/core/flags/SeriesTypeTests.kt
+++ b/core/src/test/java/com/chesire/nekome/core/flags/SeriesTypeTests.kt
@@ -1,0 +1,21 @@
+package com.chesire.nekome.core.flags
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SeriesTypeTests {
+    @Test
+    fun `forId '-1' returns SeriesType#Unknown`() {
+        assertEquals(SeriesType.Unknown, SeriesType.forId(-1))
+    }
+
+    @Test
+    fun `forId '0' returns SeriesType#Anime`() {
+        assertEquals(SeriesType.Anime, SeriesType.forId(0))
+    }
+
+    @Test
+    fun `forId '1' returns SeriesType#Manga`() {
+        assertEquals(SeriesType.Manga, SeriesType.forId(1))
+    }
+}


### PR DESCRIPTION
Search was not auto selecting which series type to use, this was because the value being stored was the ID of the control, which isn't reliable to use. Change this to use a field that is stored within the SeriesType enum, so we can reference back to that.
As part of this also fix the user being able to unselect which chip was selected.