### PR TITLE
chore: skip coverage for injection code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 ignore:
-    - "app/src/main/java/com/chesire/malime/injection/*"
-    - "app/src/main/java/com/chesire/malime/injection/**/*"
+    - "app/src/main/java/com/chesire/nekome/injection/*"
+    - "app/src/main/java/com/chesire/nekome/injection/**/*"
     - "testing/src/main/java/**/*"


### PR DESCRIPTION
The injection code shouldn't be covered by code coverage, it was still pointing to a directory for
the old application Malime, needs to be updated to point to the new application Nekome