### PR TITLE
refactor: change series list text when dates are unknown

### DIFF
--- a/app-series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesViewHolder.kt
+++ b/app-series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesViewHolder.kt
@@ -19,8 +19,6 @@ import kotlinx.android.synthetic.main.adapter_item_series.seriesProgressBar
 import kotlinx.android.synthetic.main.adapter_item_series.seriesSubtype
 import kotlinx.android.synthetic.main.adapter_item_series.seriesTitle
 
-private const val UNKNOWN_DATE = "????-??-??"
-
 /**
  * ViewHolder for Series items in the Anime or Manga list.
  */
@@ -53,26 +51,17 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
     }
 
     private fun setupDateString(model: SeriesModel) {
-        val dateString = if (model.startDate.isEmpty() && model.endDate.isEmpty()) {
-            containerView.context.getString(
-                R.string.series_list_date_range,
-                UNKNOWN_DATE,
-                UNKNOWN_DATE
-            )
-        } else if (model.startDate == model.endDate) {
-            model.startDate
-        } else if (model.endDate.isEmpty()) {
-            containerView.context.getString(
-                R.string.series_list_date_range,
-                model.startDate,
-                UNKNOWN_DATE
-            )
-        } else {
-            containerView.context.getString(
-                R.string.series_list_date_range,
-                model.startDate,
-                model.endDate
-            )
+        val dateString = with(containerView.context) {
+            when {
+                model.startDate.isEmpty() && model.endDate.isEmpty() -> getString(R.string.series_list_unknown)
+                model.startDate == model.endDate -> model.startDate
+                model.endDate.isEmpty() -> getString(
+                    R.string.series_list_date_range,
+                    model.startDate,
+                    getString(R.string.series_list_ongoing)
+                )
+                else -> getString(R.string.series_list_date_range, model.startDate, model.endDate)
+            }
         }
         seriesDate.text = dateString
     }

--- a/app/src/androidTest/java/com/chesire/nekome/flow/series/SeriesViewHolderTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/flow/series/SeriesViewHolderTests.kt
@@ -96,8 +96,8 @@ class SeriesViewHolderTests {
     }
 
     @Test
-    fun itemWithNoEndDateShowsUnknown() {
-        val expectedDate = "2020-01-31 - ????-??-??"
+    fun itemWithNoEndDateShowsOngoing() {
+        val expectedDate = "2020-01-31 - ONGOING"
 
         runBlocking {
             seriesDao.insert(createSeriesModel(startDate = "2020-01-31", endDate = ""))
@@ -115,7 +115,7 @@ class SeriesViewHolderTests {
 
     @Test
     fun itemWithNoDatesShowsUnknown() {
-        val expectedDate = "????-??-?? - ????-??-??"
+        val expectedDate = "UNKNOWN"
 
         runBlocking {
             seriesDao.insert(createSeriesModel(startDate = "", endDate = ""))

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="series_list_length">%s / %s</string>
     <string name="series_list_plus_one">+1</string>
     <string name="series_list_date_range">%s - %s</string>
+    <string name="series_list_unknown">Unknown</string>
+    <string name="series_list_ongoing">Ongoing</string>
     <string name="series_list_try_again">Series %s failed to update, please try again…</string>
     <string name="series_list_delete_title">Are you sure you want to delete %s?</string>
     <string name="series_list_delete_confirm">Confirm</string>


### PR DESCRIPTION
When the dates are unknown for the series list. Change the text so it instead shows "UNKNOWN", if
neither the start or end date are valid. And says "ONGOING" if just the end date is not known.

Closes #175 