### PR TITLE
refactor: remove user repository from series

### DIFF
--- a/app/src/main/java/com/chesire/nekome/binders/UserProviderBinder.kt
+++ b/app/src/main/java/com/chesire/nekome/binders/UserProviderBinder.kt
@@ -1,0 +1,17 @@
+package com.chesire.nekome.binders
+
+import com.chesire.nekome.account.UserRepository
+import com.chesire.nekome.series.UserProvider
+import javax.inject.Inject
+
+/**
+ * Provides a concrete class to bind the [UserProvider] interface.
+ */
+class UserProviderBinder @Inject constructor(
+    private val userRepository: UserRepository
+) : UserProvider {
+
+    override suspend fun provideUserId() = requireNotNull(userRepository.retrieveUserId()) {
+        "UserID should not be null in the database"
+    }
+}

--- a/app/src/main/java/com/chesire/nekome/injection/modules/SeriesModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/modules/SeriesModule.kt
@@ -1,8 +1,9 @@
 package com.chesire.nekome.injection.modules
 
-import com.chesire.nekome.account.UserRepository
+import com.chesire.nekome.binders.UserProviderBinder
 import com.chesire.nekome.database.dao.SeriesDao
 import com.chesire.nekome.series.SeriesRepository
+import com.chesire.nekome.series.UserProvider
 import com.chesire.nekome.server.api.LibraryApi
 import dagger.Module
 import dagger.Provides
@@ -14,9 +15,15 @@ import dagger.Provides
 @Module
 object SeriesModule {
     /**
+     * Provides a [UserProvider] to the series repository.
+     */
+    @Provides
+    fun bindUserProvider(binder: UserProviderBinder): UserProvider = binder
+
+    /**
      * Provides the [SeriesRepository] to the dependency graph.
      */
     @Provides
-    fun provideSeriesRepository(dao: SeriesDao, api: LibraryApi, user: UserRepository) =
+    fun provideSeriesRepository(dao: SeriesDao, api: LibraryApi, user: UserProvider) =
         SeriesRepository(dao, api, user)
 }

--- a/app/src/test/java/com/chesire/nekome/binders/UserProviderBinderTests.kt
+++ b/app/src/test/java/com/chesire/nekome/binders/UserProviderBinderTests.kt
@@ -1,0 +1,43 @@
+package com.chesire.nekome.binders
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.chesire.nekome.account.UserRepository
+import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UserProviderBinderTests {
+    @get:Rule
+    val taskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val coroutineRule = CoroutinesMainDispatcherRule()
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `provideUserId throws exception if no id available`() {
+        val mockRepo = mockk<UserRepository> {
+            coEvery { retrieveUserId() } returns null
+        }
+        val testObject = UserProviderBinder(mockRepo)
+
+        runBlocking { testObject.provideUserId() }
+    }
+
+    @Test
+    fun `provideUserId returns expected id`() {
+        val mockRepo = mockk<UserRepository> {
+            coEvery { retrieveUserId() } returns 2
+        }
+        val testObject = UserProviderBinder(mockRepo)
+
+        val result = runBlocking { testObject.provideUserId() }
+
+        assertEquals(2, result)
+    }
+}

--- a/series/build.gradle
+++ b/series/build.gradle
@@ -30,7 +30,6 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation project(path: ":account")
     implementation project(path: ":core")
     implementation project(path: ":database")
     implementation project(path: ":server")

--- a/series/src/main/java/com/chesire/nekome/series/UserProvider.kt
+++ b/series/src/main/java/com/chesire/nekome/series/UserProvider.kt
@@ -1,0 +1,11 @@
+package com.chesire.nekome.series
+
+/**
+ * Provider for accessing the information for a user.
+ */
+interface UserProvider {
+    /**
+     * Executes an async command to acquire the users id.
+     */
+    suspend fun provideUserId(): Int
+}

--- a/series/src/test/java/com/chesire/nekome/series/SeriesRepositoryTests.kt
+++ b/series/src/test/java/com/chesire/nekome/series/SeriesRepositoryTests.kt
@@ -1,7 +1,6 @@
 package com.chesire.nekome.series
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.chesire.nekome.account.UserRepository
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.database.dao.SeriesDao
@@ -34,8 +33,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -54,8 +53,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -74,8 +73,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addAnime(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -94,8 +93,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -114,8 +113,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -134,8 +133,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { addManga(any(), any(), any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -156,8 +155,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns Resource.Success(Any())
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -176,8 +175,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -198,8 +197,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { delete(any()) } returns expected
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -220,8 +219,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveAnime(any()) } returns response
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -240,8 +239,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveAnime(any()) } returns response
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -260,8 +259,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveManga(any()) } returns response
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -280,8 +279,8 @@ class SeriesRepositoryTests {
         val mockApi = mockk<LibraryApi> {
             coEvery { retrieveManga(any()) } returns response
         }
-        val mockUser = mockk<UserRepository> {
-            coEvery { retrieveUserId() } returns 1
+        val mockUser = mockk<UserProvider> {
+            coEvery { provideUserId() } returns 1
         }
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
@@ -304,7 +303,7 @@ class SeriesRepositoryTests {
                 Resource.Success(expected)
             }
         }
-        val mockUser = mockk<UserRepository>()
+        val mockUser = mockk<UserProvider>()
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
         classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current)
@@ -324,7 +323,7 @@ class SeriesRepositoryTests {
                 Resource.Error("")
             }
         }
-        val mockUser = mockk<UserRepository>()
+        val mockUser = mockk<UserProvider>()
 
         val classUnderTest = SeriesRepository(mockDao, mockApi, mockUser)
         val result = classUnderTest.updateSeries(0, 0, UserSeriesStatus.Current)


### PR DESCRIPTION
Within the SeriesRepository was a reference to the UserRepository, this shouldn't occur. To fix this create an interface and pass an object implementing it into the SeriesRepository.