### PR TITLE
chore: add github actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,12 @@ updates:
   open-pull-requests-limit: 30
   assignees:
   - Chesire
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '09:00'
+  open-pull-requests-limit: 30
+  assignees:
+  - Chesire


### PR DESCRIPTION
Ensure that the github actions versions are alll updated to their latest versions