### PR TITLE
feat: adds default home screen option

### DIFF
--- a/app/src/main/java/com/chesire/nekome/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/Activity.kt
@@ -20,7 +20,9 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.lifecycle.lifecycleOwner
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.core.AuthCaster
+import com.chesire.nekome.core.flags.HomeScreenOptions
 import com.chesire.nekome.core.nav.Flow
+import com.chesire.nekome.core.settings.ApplicationSettings
 import com.chesire.nekome.core.viewmodel.ViewModelFactory
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
@@ -38,6 +40,9 @@ import javax.inject.Inject
 class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow {
     @Inject
     lateinit var authCaster: AuthCaster
+
+    @Inject
+    lateinit var settings: ApplicationSettings
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
@@ -110,6 +115,16 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow 
                 }
             }
         }
+
+        if (settings.defaultHomeScreen == HomeScreenOptions.Anime) {
+            findNavController(R.id.activityNavigation).navigate(
+                OverviewNavGraphDirections.globalToAnimeFragment()
+            )
+        } else {
+            findNavController(R.id.activityNavigation).navigate(
+                OverviewNavGraphDirections.globalToMangaFragment()
+            )
+        }
     }
 
     override fun onSupportNavigateUp() =
@@ -164,8 +179,14 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow 
     }
 
     override fun finishLogin() {
-        findNavController(R.id.activityNavigation).navigate(
-            OverviewNavGraphDirections.globalToAnimeFragment()
-        )
+        if (settings.defaultHomeScreen == HomeScreenOptions.Anime) {
+            findNavController(R.id.activityNavigation).navigate(
+                OverviewNavGraphDirections.globalToAnimeFragment()
+            )
+        } else {
+            findNavController(R.id.activityNavigation).navigate(
+                OverviewNavGraphDirections.globalToMangaFragment()
+            )
+        }
     }
 }

--- a/app/src/main/java/com/chesire/nekome/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/Activity.kt
@@ -116,15 +116,7 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow 
             }
         }
 
-        if (settings.defaultHomeScreen == HomeScreenOptions.Anime) {
-            findNavController(R.id.activityNavigation).navigate(
-                OverviewNavGraphDirections.globalToAnimeFragment()
-            )
-        } else {
-            findNavController(R.id.activityNavigation).navigate(
-                OverviewNavGraphDirections.globalToMangaFragment()
-            )
-        }
+        navigateToDefaultHome()
     }
 
     override fun onSupportNavigateUp() =
@@ -179,6 +171,10 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow 
     }
 
     override fun finishLogin() {
+        navigateToDefaultHome()
+    }
+
+    private fun navigateToDefaultHome() {
         if (settings.defaultHomeScreen == HomeScreenOptions.Anime) {
             findNavController(R.id.activityNavigation).navigate(
                 OverviewNavGraphDirections.globalToAnimeFragment()

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -42,6 +42,12 @@
         app:popUpToInclusive="true" />
 
     <action
+        android:id="@+id/globalToMangaFragment"
+        app:destination="@id/mangaFragment"
+        app:popUpTo="@+id/overview_nav_graph"
+        app:popUpToInclusive="true" />
+
+    <action
         android:id="@+id/globalToDetailsFragment"
         app:destination="@id/login_nav_graph"
         app:popUpTo="@+id/overview_nav_graph"

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/SettingsFragment.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/SettingsFragment.kt
@@ -9,6 +9,7 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.chesire.lifecyklelog.LogLifecykle
+import com.chesire.nekome.core.flags.HomeScreenOptions
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.settings.Theme
 
@@ -21,6 +22,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private lateinit var keyLicenses: String
     private lateinit var keyGithub: String
     private lateinit var keyDefaultSeriesState: String
+    private lateinit var keyDefaultHomeScreen: String
     private lateinit var keyTheme: String
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -29,9 +31,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
         keyLicenses = getString(R.string.key_licenses)
         keyGithub = getString(R.string.key_github)
         keyDefaultSeriesState = getString(R.string.key_default_series_state)
+        keyDefaultHomeScreen = getString(R.string.key_default_home)
         keyTheme = getString(R.string.key_theme)
 
         setupDefaultSeriesState()
+        setupDefaultHomeScreen()
         setupTheme()
     }
 
@@ -42,6 +46,17 @@ class SettingsFragment : PreferenceFragmentCompat() {
             pref.entryValues = userSeriesMap.keys.map { it.toString() }.toTypedArray()
             if (pref.value == null) {
                 pref.value = UserSeriesStatus.Current.index.toString()
+            }
+        }
+    }
+
+    private fun setupDefaultHomeScreen() {
+        findPreference<ListPreference>(keyDefaultHomeScreen)?.let { pref ->
+            val homeScreenOptionsMap = HomeScreenOptions.getValueMap(requireContext())
+            pref.entries = homeScreenOptionsMap.values.toTypedArray()
+            pref.entryValues = homeScreenOptionsMap.keys.map { it.toString() }.toTypedArray()
+            if (pref.value == null) {
+                pref.value = HomeScreenOptions.Anime.index.toString()
             }
         }
     }

--- a/features/settings/src/main/res/xml/preferences.xml
+++ b/features/settings/src/main/res/xml/preferences.xml
@@ -9,8 +9,8 @@
 
         <ListPreference
             android:key="@string/key_default_home"
-            android:title="@string/settings_default_home_title"
-            android:summary="@string/settings_default_home_summary" />
+            android:summary="@string/settings_default_home_summary"
+            android:title="@string/settings_default_home_title" />
 
         <ListPreference
             android:key="@string/key_theme"

--- a/features/settings/src/main/res/xml/preferences.xml
+++ b/features/settings/src/main/res/xml/preferences.xml
@@ -8,6 +8,11 @@
             android:title="@string/settings_default_series_status_title" />
 
         <ListPreference
+            android:key="@string/key_default_home"
+            android:title="@string/settings_default_home_title"
+            android:summary="@string/settings_default_home_summary" />
+
+        <ListPreference
             android:key="@string/key_theme"
             android:title="@string/settings_theme"
             app:useSimpleSummaryProvider="true" />

--- a/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
@@ -5,11 +5,11 @@ import androidx.annotation.StringRes
 import com.chesire.nekome.core.R
 
 /**
- * All possible types of a series.
+ * Options for default home screen
  */
 enum class HomeScreenOptions(val index: Int, @StringRes val stringId: Int) {
-    Anime(0, R.string.anime),
-    Manga(1, R.string.manga);
+    Anime(0, R.string.nav_anime),
+    Manga(1, R.string.nav_manga);
 
     companion object {
         /**
@@ -19,7 +19,7 @@ enum class HomeScreenOptions(val index: Int, @StringRes val stringId: Int) {
             .associate { it.index to context.getString(it.stringId) }
 
         /**
-         * Gets the [UserSeriesStatus] from a given [index], the [index] should be the index field
+         * Gets the [HomeScreenOptions] from a given [index], the [index] should be the index field.
          * in the the enum class, but as a string.
          */
         fun getFromIndex(index: String): HomeScreenOptions {

--- a/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import com.chesire.nekome.core.R
 
 /**
- * Options for default home screen
+ * Options for default home screen.
  */
 enum class HomeScreenOptions(val index: Int, @StringRes val stringId: Int) {
     Anime(0, R.string.nav_anime),

--- a/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/flags/HomeScreenOptions.kt
@@ -1,0 +1,31 @@
+package com.chesire.nekome.core.flags
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.chesire.nekome.core.R
+
+/**
+ * All possible types of a series.
+ */
+enum class HomeScreenOptions(val index: Int, @StringRes val stringId: Int) {
+    Anime(0, R.string.anime),
+    Manga(1, R.string.manga);
+
+    companion object {
+        /**
+         * Gets a map of [index] to the string acquired from the [stringId].
+         */
+        fun getValueMap(context: Context) = HomeScreenOptions.values()
+            .associate { it.index to context.getString(it.stringId) }
+
+        /**
+         * Gets the [UserSeriesStatus] from a given [index], the [index] should be the index field
+         * in the the enum class, but as a string.
+         */
+        fun getFromIndex(index: String): HomeScreenOptions {
+            return index.toIntOrNull()?.let { intIndex ->
+                HomeScreenOptions.values().find { it.index == intIndex } ?: Anime
+            } ?: Anime
+        }
+    }
+}

--- a/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
@@ -52,7 +52,7 @@ class ApplicationSettings @Inject constructor(
         }
 
     /**
-     * Gets the default [HomeScreenOption] the home screen that shows after login
+     * Gets the default [HomeScreenOptions] the home screen that shows after login or when re-launching.
      */
     val defaultHomeScreen: HomeScreenOptions
         get() {
@@ -62,7 +62,7 @@ class ApplicationSettings @Inject constructor(
                     HomeScreenOptions.Anime.index.toString()
                 )
             ) {
-                "Preferences defaultSeriesState returned null, with supplied default value"
+                "Preferences defaultHomeScreen returned null, with supplied default value"
             }
 
             return HomeScreenOptions.getFromIndex(index)

--- a/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.chesire.nekome.core.R
-import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.flags.HomeScreenOptions
+import com.chesire.nekome.core.flags.UserSeriesStatus
 import javax.inject.Inject
 
 /**

--- a/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
@@ -3,6 +3,7 @@ package com.chesire.nekome.core.settings
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.chesire.nekome.core.flags.HomeScreenOptions
 import com.chesire.nekome.core.R
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import javax.inject.Inject
@@ -18,6 +19,7 @@ class ApplicationSettings @Inject constructor(
 ) {
 
     private val _defaultSeriesState = context.getString(R.string.key_default_series_state)
+    private val _defaultHomeScreen = context.getString(R.string.key_default_home)
     private val _theme = context.getString(R.string.key_theme)
 
     /**
@@ -47,6 +49,24 @@ class ApplicationSettings @Inject constructor(
             }
 
             return status
+        }
+
+
+    /**
+     * Gets the default [HomeScreenOption] the home screen that shows after login
+     */
+    val defaultHomeScreen: HomeScreenOptions
+        get() {
+            val index = requireNotNull(
+                preferences.getString(
+                    _defaultHomeScreen,
+                    HomeScreenOptions.Anime.index.toString()
+                )
+            ) {
+                "Preferences defaultSeriesState returned null, with supplied default value"
+            }
+
+            return HomeScreenOptions.getFromIndex(index)
         }
 
     /**

--- a/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/settings/ApplicationSettings.kt
@@ -3,9 +3,9 @@ package com.chesire.nekome.core.settings
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import com.chesire.nekome.core.flags.HomeScreenOptions
 import com.chesire.nekome.core.R
 import com.chesire.nekome.core.flags.UserSeriesStatus
+import com.chesire.nekome.core.flags.HomeScreenOptions
 import javax.inject.Inject
 
 /**
@@ -50,7 +50,6 @@ class ApplicationSettings @Inject constructor(
 
             return status
         }
-
 
     /**
      * Gets the default [HomeScreenOption] the home screen that shows after login

--- a/libraries/core/src/main/res/values/keys.xml
+++ b/libraries/core/src/main/res/values/keys.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="key_default_series_state" translatable="false">keyDefaultSeriesState</string>
+    <string name="key_default_home" translatable="false">keyDefaultHomeScreen</string>
     <string name="key_theme" translatable="false">keyTheme</string>
 </resources>

--- a/libraries/core/src/main/res/values/strings.xml
+++ b/libraries/core/src/main/res/values/strings.xml
@@ -123,6 +123,4 @@
     <string name="results_failure">Failed to begin tracking series %s, please try again…</string>
 
     <string name="error_generic">An unknown error has occurred…</string>
-    <string name="anime">Anime</string>
-    <string name="manga">Manga</string>
 </resources>

--- a/libraries/core/src/main/res/values/strings.xml
+++ b/libraries/core/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
     <string name="settings_default_series_status_title">Default Series Status</string>
     <string name="settings_default_series_status_summary">Status a newly tracked series will start in</string>
+    <string name="settings_default_home_title">Default Home Screen</string>
+    <string name="settings_default_home_summary">Choose between Anime/Manga</string>
     <string name="settings_theme">Theme</string>
     <string name="settings_theme_system">Use system default</string>
     <string name="settings_theme_dark">Dark</string>
@@ -121,4 +123,6 @@
     <string name="results_failure">Failed to begin tracking series %s, please try again…</string>
 
     <string name="error_generic">An unknown error has occurred…</string>
+    <string name="anime">Anime</string>
+    <string name="manga">Manga</string>
 </resources>

--- a/libraries/core/src/test/java/com/chesire/nekome/core/flags/HomeScreenOptionsTests.kt
+++ b/libraries/core/src/test/java/com/chesire/nekome/core/flags/HomeScreenOptionsTests.kt
@@ -1,0 +1,62 @@
+package com.chesire.nekome.core.flags
+
+import android.content.Context
+import com.chesire.nekome.core.R
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeScreenOptionsTests {
+    @Test
+    fun `getValueMap returns expected map`() {
+        val mockContext = mockk<Context> {
+            every { getString(R.string.nav_anime) } returns "Anime"
+            every { getString(R.string.nav_manga) } returns "Manga"
+        }
+        val map = HomeScreenOptions.getValueMap(mockContext)
+
+        assertEquals("Anime", map.getValue(0))
+        assertEquals("Manga", map.getValue(1))
+    }
+
+    @Test
+    fun `getFromIndex with non int value returns default option`() {
+        assertEquals(
+            HomeScreenOptions.Anime,
+            HomeScreenOptions.getFromIndex("not an int")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with out of range value returns default option`() {
+        assertEquals(
+            HomeScreenOptions.Anime,
+            HomeScreenOptions.getFromIndex("99")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '-1' value returns default option`() {
+        assertEquals(
+            HomeScreenOptions.Anime,
+            HomeScreenOptions.getFromIndex("-1")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '0' value returns Current value`() {
+        assertEquals(
+            HomeScreenOptions.Anime,
+            HomeScreenOptions.getFromIndex("0")
+        )
+    }
+
+    @Test
+    fun `getFromIndex with '1' value returns Completed value`() {
+        assertEquals(
+            HomeScreenOptions.Manga,
+            HomeScreenOptions.getFromIndex("1")
+        )
+    }
+}

--- a/libraries/core/src/test/java/com/chesire/nekome/core/settings/ApplicationSettingsTests.kt
+++ b/libraries/core/src/test/java/com/chesire/nekome/core/settings/ApplicationSettingsTests.kt
@@ -3,6 +3,7 @@ package com.chesire.nekome.core.settings
 import android.content.Context
 import android.content.SharedPreferences
 import com.chesire.nekome.core.R
+import com.chesire.nekome.core.flags.HomeScreenOptions
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import io.mockk.Runs
 import io.mockk.every
@@ -14,8 +15,42 @@ import org.junit.Test
 
 class ApplicationSettingsTests {
     private val mockContext = mockk<Context> {
+        every { getString(R.string.key_default_home) } returns "key_default_home"
         every { getString(R.string.key_default_series_state) } returns "key_default_series_state"
         every { getString(R.string.key_theme) } returns "key_theme"
+    }
+
+    @Test
+    fun `can get defaultHomeScreen`() {
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getString("key_default_home", "0") } returns "1"
+        }
+        val testObject = ApplicationSettings(
+            mockContext,
+            mockPreferences
+        )
+
+        assertEquals(HomeScreenOptions.Manga, testObject.defaultHomeScreen)
+    }
+
+    @Test
+    fun `defaultHomeScreen with Unknown value returns Anime`() {
+        val mockEditor = mockk<SharedPreferences.Editor> {
+            every { putString("key_default_home", "0") } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { getString("key_default_home", "0") } returns "-1"
+            every { edit() } returns mockEditor
+        }
+        val testObject = ApplicationSettings(
+            mockContext,
+            mockPreferences
+        )
+
+        val result = testObject.defaultHomeScreen
+
+        assertEquals(HomeScreenOptions.Anime, result)
     }
 
     @Test


### PR DESCRIPTION
- Updates navigation graph to have a global navigation option for manga similar to anime
- Adds an additional configuration for switching between anime/manga as similar to `UserSeriesStatus`
- Creates a preference to store the value of default home option and related string resources
- Adds logic to choose between navigating to anime or manga based on the stored option

Fixes #93 