### PR TITLE
style: switch from using Observer to using Kotlin SAM

### DIFF
--- a/app/src/main/java/com/chesire/nekome/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/Activity.kt
@@ -10,7 +10,6 @@ import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_LOCKED_CLOSED
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_UNLOCKED
-import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
@@ -64,16 +63,11 @@ class Activity : DaggerAppCompatActivity(), AuthCaster.AuthCasterListener, Flow 
     }
 
     private fun observeViewModel() {
-        viewModel.user.observe(
-            this,
-            Observer { userModel ->
-                if (userModel == null) {
-                    return@Observer
-                }
-
+        viewModel.user.observe(this) { userModel ->
+            if (userModel != null) {
                 updateAvatar(findViewById(R.id.activityNavigationView), userModel)
             }
-        )
+        }
     }
 
     override fun onDestroy() {

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/DiscoverFragment.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/DiscoverFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.chesire.lifecyklelog.LogLifecykle
@@ -56,35 +55,29 @@ class DiscoverFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.trendingAnime.observe(
-            viewLifecycleOwner,
-            Observer { state ->
-                when (state) {
-                    is AsyncState.Success -> animeTrendingAdapter.submitList(state.data)
-                    is AsyncState.Error -> {
-                        // Show snackbar
-                        // Show error view on trending anime
-                    }
-                    is AsyncState.Loading -> {
-                        // Show loading view
-                    }
+        viewModel.trendingAnime.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is AsyncState.Success -> animeTrendingAdapter.submitList(state.data)
+                is AsyncState.Error -> {
+                    // Show snackbar
+                    // Show error view on trending anime
+                }
+                is AsyncState.Loading -> {
+                    // Show loading view
                 }
             }
-        )
-        viewModel.trendingManga.observe(
-            viewLifecycleOwner,
-            Observer { state ->
-                when (state) {
-                    is AsyncState.Success -> mangaTrendingAdapter.submitList(state.data)
-                    is AsyncState.Error -> {
-                        // Show snackbar
-                        // Show error view on trending manga
-                    }
-                    is AsyncState.Loading -> {
-                        // Show loading view
-                    }
+        }
+        viewModel.trendingManga.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is AsyncState.Success -> mangaTrendingAdapter.submitList(state.data)
+                is AsyncState.Error -> {
+                    // Show snackbar
+                    // Show error view on trending manga
+                }
+                is AsyncState.Loading -> {
+                    // Show loading view
                 }
             }
-        )
+        }
     }
 }

--- a/features/login/src/main/java/com/chesire/nekome/app/login/details/DetailsFragment.kt
+++ b/features/login/src/main/java/com/chesire/nekome/app/login/details/DetailsFragment.kt
@@ -6,7 +6,6 @@ import android.view.inputmethod.EditorInfo
 import androidx.annotation.StringRes
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.app.login.R
@@ -56,7 +55,7 @@ class DetailsFragment : DaggerFragment(R.layout.fragment_details) {
         binding.loginButton.setOnClickListener { executeLogin() }
 
         setupLinks()
-        viewModel.loginStatus.observe(viewLifecycleOwner, Observer { loginStatusChanged(it) })
+        viewModel.loginStatus.observe(viewLifecycleOwner) { loginStatusChanged(it) }
     }
 
     private fun setupLinks() {

--- a/features/login/src/main/java/com/chesire/nekome/app/login/syncing/SyncingFragment.kt
+++ b/features/login/src/main/java/com/chesire/nekome/app/login/syncing/SyncingFragment.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import coil.load
 import coil.transform.CircleCropTransformation
 import com.chesire.lifecyklelog.LogLifecykle
@@ -44,24 +43,15 @@ class SyncingFragment : DaggerFragment(R.layout.fragment_syncing) {
     }
 
     private fun observeAvatar() {
-        viewModel.avatarUrl.observe(
-            viewLifecycleOwner,
-            Observer {
-                binding.profileImage.load(it) {
-                    transformations(CircleCropTransformation())
-                    placeholder(R.drawable.ic_account_circle)
-                    error(R.drawable.ic_account_circle)
-                }
+        viewModel.avatarUrl.observe(viewLifecycleOwner) {
+            binding.profileImage.load(it) {
+                transformations(CircleCropTransformation())
+                placeholder(R.drawable.ic_account_circle)
+                error(R.drawable.ic_account_circle)
             }
-        )
+        }
     }
 
-    private fun observeSyncStatus() {
-        viewModel.syncStatus.observe(
-            viewLifecycleOwner,
-            Observer {
-                flow.finishLogin()
-            }
-        )
-    }
+    private fun observeSyncStatus() =
+        viewModel.syncStatus.observe(viewLifecycleOwner) { flow.finishLogin() }
 }

--- a/features/profile/src/main/java/com/chesire/nekome/app/profile/ProfileFragment.kt
+++ b/features/profile/src/main/java/com/chesire/nekome/app/profile/ProfileFragment.kt
@@ -3,7 +3,6 @@ package com.chesire.nekome.app.profile
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import coil.load
 import coil.transform.CircleCropTransformation
 import com.chesire.lifecyklelog.LogLifecykle
@@ -33,14 +32,9 @@ class ProfileFragment : DaggerFragment(R.layout.fragment_profile) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentProfileBinding.bind(view)
 
-        viewModel.user.observe(
-            viewLifecycleOwner,
-            Observer {
-                if (it != null) {
-                    setImagery(it)
-                }
-            }
-        )
+        viewModel.user.observe(viewLifecycleOwner) { userModel ->
+            userModel?.let { setImagery(it) }
+        }
     }
 
     private fun setImagery(user: UserModel) {

--- a/features/search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/SearchFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.app.search.databinding.FragmentSearchBinding
@@ -76,26 +75,23 @@ class SearchFragment : DaggerFragment(R.layout.fragment_search) {
     }
 
     private fun observeSearchResults() {
-        viewModel.searchResult.observe(
-            viewLifecycleOwner,
-            Observer { result ->
-                when (result) {
-                    is AsyncState.Success -> {
-                        hideSpinner()
-                        findNavController().navigate(
-                            SearchFragmentDirections.toResultsFragment(
-                                result.data.toTypedArray()
-                            )
+        viewModel.searchResult.observe(viewLifecycleOwner) { result ->
+            when (result) {
+                is AsyncState.Success -> {
+                    hideSpinner()
+                    findNavController().navigate(
+                        SearchFragmentDirections.toResultsFragment(
+                            result.data.toTypedArray()
                         )
-                    }
-                    is AsyncState.Error -> {
-                        hideSpinner()
-                        parseSearchError(result.error)
-                    }
-                    is AsyncState.Loading -> showSpinner()
+                    )
                 }
+                is AsyncState.Error -> {
+                    hideSpinner()
+                    parseSearchError(result.error)
+                }
+                is AsyncState.Loading -> showSpinner()
             }
-        )
+        }
     }
 
     private fun parseSearchError(error: SearchError) {

--- a/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsFragment.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsFragment.kt
@@ -3,7 +3,6 @@ package com.chesire.nekome.app.search.results
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.chesire.lifecyklelog.LogLifecykle
@@ -42,13 +41,8 @@ class ResultsFragment : DaggerFragment(R.layout.fragment_results), ResultsListen
         }
     }
 
-    private fun observeSeries() {
-        viewModel.series.observe(
-            viewLifecycleOwner,
-            Observer {
-                resultsAdapter.allSeries = it
-            }
-        )
+    private fun observeSeries() = viewModel.series.observe(viewLifecycleOwner) { series ->
+        resultsAdapter.allSeries = series
     }
 
     override fun onTrack(model: SeriesModel, callback: () -> Unit) {

--- a/features/series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailSheetFragment.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailSheetFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.app.series.R
 import com.chesire.nekome.app.series.databinding.FragmentSeriesDetailBinding
@@ -87,25 +86,22 @@ class SeriesDetailSheetFragment : BottomSheetDialogFragment() {
             binding.detailConfirmation.confirmationProgress.hide(invisible = true)
         }
 
-        viewModel.updatingStatus.observe(
-            viewLifecycleOwner,
-            Observer { result ->
-                when (result) {
-                    is AsyncState.Loading -> startInProgressState()
-                    is AsyncState.Error -> {
-                        endInProgressState()
-                        view?.let { view ->
-                            Snackbar.make(
-                                view.findViewById(R.id.seriesDetailLayout),
-                                getString(R.string.series_detail_failure, result.data?.seriesName),
-                                Snackbar.LENGTH_LONG
-                            ).show()
-                        }
+        viewModel.updatingStatus.observe(viewLifecycleOwner) { result ->
+            when (result) {
+                is AsyncState.Loading -> startInProgressState()
+                is AsyncState.Error -> {
+                    endInProgressState()
+                    view?.let { view ->
+                        Snackbar.make(
+                            view.findViewById(R.id.seriesDetailLayout),
+                            getString(R.string.series_detail_failure, result.data?.seriesName),
+                            Snackbar.LENGTH_LONG
+                        ).show()
                     }
-                    is AsyncState.Success -> dismiss()
                 }
+                is AsyncState.Success -> dismiss()
             }
-        )
+        }
     }
 
     private fun setupSeriesStatusListener(model: MutableSeriesModel) {

--- a/features/series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/list/SeriesListFragment.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.ImageView
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.afollestad.materialdialogs.MaterialDialog
@@ -78,19 +77,16 @@ abstract class SeriesListFragment :
 
         binding.refreshLayout.setOnRefreshListener { startRefreshingSeries() }
 
-        viewModel.series.observe(
-            viewLifecycleOwner,
-            Observer { series ->
-                val newList = series.filter { it.type == seriesType }
-                Timber.d("New list provided, new count [${newList.count()}]")
-                seriesAdapter.submitList(newList)
-                if (binding.listContent.emptyView == null) {
-                    // Set the empty view here so it doesn't show on load before we get series
-                    Timber.d("Setting in the RecyclerViews empty view")
-                    binding.listContent.emptyView = binding.listEmpty.root
-                }
+        viewModel.series.observe(viewLifecycleOwner) { series ->
+            val newList = series.filter { it.type == seriesType }
+            Timber.d("New list provided, new count [${newList.count()}]")
+            seriesAdapter.submitList(newList)
+            if (binding.listContent.emptyView == null) {
+                // Set the empty view here so it doesn't show on load before we get series
+                Timber.d("Setting in the RecyclerViews empty view")
+                binding.listContent.emptyView = binding.listEmpty.root
             }
-        )
+        }
 
         observeSeriesDeletion()
         observeSeriesRefresh()
@@ -161,22 +157,19 @@ abstract class SeriesListFragment :
     }
 
     private fun observeSeriesDeletion() {
-        viewModel.deletionStatus.observe(
-            viewLifecycleOwner,
-            Observer { state ->
-                if (state is AsyncState.Error && state.error == SeriesListDeleteError.DeletionFailure) {
-                    Snackbar.make(
-                        binding.seriesListLayout,
-                        R.string.series_list_delete_failure,
-                        Snackbar.LENGTH_INDEFINITE
-                    ).setAction(R.string.series_list_delete_retry) {
-                        state.data?.let { seriesModel ->
-                            viewModel.deleteSeries(seriesModel)
-                        }
-                    }.show()
-                }
+        viewModel.deletionStatus.observe(viewLifecycleOwner) { state ->
+            if (state is AsyncState.Error && state.error == SeriesListDeleteError.DeletionFailure) {
+                Snackbar.make(
+                    binding.seriesListLayout,
+                    R.string.series_list_delete_failure,
+                    Snackbar.LENGTH_INDEFINITE
+                ).setAction(R.string.series_list_delete_retry) {
+                    state.data?.let { seriesModel ->
+                        viewModel.deleteSeries(seriesModel)
+                    }
+                }.show()
             }
-        )
+        }
     }
 
     private fun startRefreshingSeries() {
@@ -188,22 +181,19 @@ abstract class SeriesListFragment :
     }
 
     private fun observeSeriesRefresh() {
-        viewModel.refreshStatus.observe(
-            viewLifecycleOwner,
-            Observer { state ->
-                when (state) {
-                    is AsyncState.Success -> endRefreshingSeries()
-                    is AsyncState.Error -> {
-                        Timber.w("Error trying to refresh series - ${state.error}")
-                        endRefreshingSeries()
-                        Snackbar.make(
-                            binding.seriesListLayout,
-                            R.string.series_list_refresh_error,
-                            Snackbar.LENGTH_LONG
-                        ).show()
-                    }
+        viewModel.refreshStatus.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is AsyncState.Success -> endRefreshingSeries()
+                is AsyncState.Error -> {
+                    Timber.w("Error trying to refresh series - ${state.error}")
+                    endRefreshingSeries()
+                    Snackbar.make(
+                        binding.seriesListLayout,
+                        R.string.series_list_refresh_error,
+                        Snackbar.LENGTH_LONG
+                    ).show()
                 }
             }
-        )
+        }
     }
 }


### PR DESCRIPTION
Instead of having to do `observe(viewLifecycleOwner, Observer {...)` switch to using the Kotlin SAM
so we can instead do `observe(viewLifecycleOwner) {...` to make it a bit cleaner