### PR TITLE
ci: change from using pull_request to pull_request_target

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
 
 jobs:
   test:
@@ -43,7 +45,7 @@ jobs:
 
   danger:
     needs: [test, analyze]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -68,7 +70,6 @@ jobs:
         name: lint
         path: build/reports/
     - uses: MeilCli/danger-action@v5.0.0
-      if: github.event_name == 'pull_request'
       with:
         plugins_file: 'Gemfile'
         install_path: 'vendor/bundle'


### PR DESCRIPTION
Using pull_request_target should allow forks to still run the Danger step
it was added to allow using secret env variables in situations such as
these.