### PR TITLE
chore: update the gradle wrapper to use the -all version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 19 20:52:08 BST 2020
+#Sat Nov 07 17:28:32 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Instead of using the -bin option for gradle, switch to the -all option which is recommended