### PR TITLE
chore: remove the material dialog inputs dependency

### DIFF
--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
-    implementation "com.afollestad.material-dialogs:input:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"


### PR DESCRIPTION
Dependency isn't used, as we only use the Core material dialog in actuality