### PR TITLE
fix: r8 removing material dialog files

### DIFF
--- a/features/series/src/main/res/raw/keep.xml
+++ b/features/series/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@layout/md_dialog_*" />


### PR DESCRIPTION
When running R8 over the project during build, it removes some of the MaterialDialog resource files,
causing a crash when attempting to open them. Add a `keep` file that will keep those resources