### PR TITLE
chore: cleanup the project build.gradle

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -44,6 +44,11 @@
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
+    <codeStyleSettings language="Groovy">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 apply plugin: "androidx.navigation.safeargs.kotlin"
+apply from: "${project.rootDir}/ext.gradle"
 
 android {
     compileSdkVersion sdk_version
@@ -12,7 +13,7 @@ android {
         minSdkVersion 21
         targetSdkVersion sdk_version
         versionCode 1
-        versionName "${appVersion()}"
+        versionName appVersionFromTag()
         testInstrumentationRunner "com.chesire.nekome.TestRunner"
         resConfigs "en"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -39,18 +39,3 @@ task clean(type: Delete) {
 
 apply from: "dependencies.gradle"
 apply from: "detekt.gradle"
-
-ext.appVersion = {
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine "git", "describe", "--tags", "--always"
-        standardOutput = stdout
-    }
-
-    def longTag = stdout.toString().trim()
-    if (longTag.contains('-')) {
-        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
-    } else {
-        return longTag
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -33,39 +33,11 @@ subprojects {
     apply from: "${project.rootDir}/jacoco.gradle"
 }
 
-detekt {
-    config = files("detekt.yml")
-    input = files(
-            "app/src/main/java",
-            "features/discover/src/main/java",
-            "features/profile/src/main/java",
-            "features/search/src/main/java",
-            "features/series/src/main/java",
-            "features/settings/src/main/java",
-            "features/timeline/src/main/java",
-            "libraries/account/src/main/java",
-            "libraries/core/src/main/java",
-            "libraries/database/src/main/java",
-            "libraries/kitsu/src/main/java",
-            "libraries/library/src/main/java",
-            "libraries/server/src/main/java",
-            "testing/src/main/java"
-    )
-    reports {
-        xml {
-            enabled = true
-            destination = file("build/reports/detekt/detekt.xml")
-        }
-        html {
-            enabled = true
-            destination = file("build/reports/detekt/detekt.html")
-        }
-    }
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: "detekt.gradle"
 
 ext {
     sdk_version = 30

--- a/build.gradle
+++ b/build.gradle
@@ -37,29 +37,8 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
+apply from: "dependencies.gradle"
 apply from: "detekt.gradle"
-
-ext {
-    sdk_version = 30
-
-    appcompat_version = "1.2.0"
-    coil_version = "1.0.0"
-    constraint_layout_version = "2.0.4"
-    corektx_version = "1.5.0-alpha04"
-    coroutines_version = "1.4.1"
-    dagger_version = "2.29.1"
-    fragmentctx_version = "1.2.5"
-    lifecycle_version = "2.2.0"
-    lifecykle_version = "3.0.0"
-    lintrules_version = "1.2.5"
-    liveevent_version = "1.2.0"
-    material_version = "1.3.0-alpha03"
-    materialdialog_version = "3.3.0"
-    moshi_version = "1.11.0"
-    preferences_version = "1.1.1"
-    room_version = "2.2.5"
-    timber_version = "4.7.1"
-}
 
 ext.appVersion = {
     def stdout = new ByteArrayOutputStream()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,21 @@
+ext {
+    sdk_version = 30
+
+    appcompat_version = "1.2.0"
+    coil_version = "1.0.0"
+    constraint_layout_version = "2.0.4"
+    corektx_version = "1.5.0-alpha04"
+    coroutines_version = "1.4.1"
+    dagger_version = "2.29.1"
+    fragmentctx_version = "1.2.5"
+    lifecycle_version = "2.2.0"
+    lifecykle_version = "3.0.0"
+    lintrules_version = "1.2.5"
+    liveevent_version = "1.2.0"
+    material_version = "1.3.0-alpha03"
+    materialdialog_version = "3.3.0"
+    moshi_version = "1.11.0"
+    preferences_version = "1.1.1"
+    room_version = "2.2.5"
+    timber_version = "4.7.1"
+}

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -1,0 +1,29 @@
+detekt {
+    config = files("detekt.yml")
+    input = files(
+            "app/src/main/java",
+            "features/discover/src/main/java",
+            "features/profile/src/main/java",
+            "features/search/src/main/java",
+            "features/series/src/main/java",
+            "features/settings/src/main/java",
+            "features/timeline/src/main/java",
+            "libraries/account/src/main/java",
+            "libraries/core/src/main/java",
+            "libraries/database/src/main/java",
+            "libraries/kitsu/src/main/java",
+            "libraries/library/src/main/java",
+            "libraries/server/src/main/java",
+            "testing/src/main/java"
+    )
+    reports {
+        xml {
+            enabled = true
+            destination = file("build/reports/detekt/detekt.xml")
+        }
+        html {
+            enabled = true
+            destination = file("build/reports/detekt/detekt.html")
+        }
+    }
+}

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -3,6 +3,7 @@ detekt {
     input = files(
             "app/src/main/java",
             "features/discover/src/main/java",
+            "features/login/src/main/java",
             "features/profile/src/main/java",
             "features/search/src/main/java",
             "features/series/src/main/java",

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -1,21 +1,21 @@
 detekt {
     config = files("detekt.yml")
     input = files(
-            "app/src/main/java",
-            "features/discover/src/main/java",
-            "features/login/src/main/java",
-            "features/profile/src/main/java",
-            "features/search/src/main/java",
-            "features/series/src/main/java",
-            "features/settings/src/main/java",
-            "features/timeline/src/main/java",
-            "libraries/account/src/main/java",
-            "libraries/core/src/main/java",
-            "libraries/database/src/main/java",
-            "libraries/kitsu/src/main/java",
-            "libraries/library/src/main/java",
-            "libraries/server/src/main/java",
-            "testing/src/main/java"
+        "app/src/main/java",
+        "features/discover/src/main/java",
+        "features/login/src/main/java",
+        "features/profile/src/main/java",
+        "features/search/src/main/java",
+        "features/series/src/main/java",
+        "features/settings/src/main/java",
+        "features/timeline/src/main/java",
+        "libraries/account/src/main/java",
+        "libraries/core/src/main/java",
+        "libraries/database/src/main/java",
+        "libraries/kitsu/src/main/java",
+        "libraries/library/src/main/java",
+        "libraries/server/src/main/java",
+        "testing/src/main/java"
     )
     reports {
         xml {

--- a/ext.gradle
+++ b/ext.gradle
@@ -1,0 +1,18 @@
+/**
+ * Generates a string to use for the "versionName" from the git tag.
+ */
+ext.appVersionFromTag = {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine "git", "describe", "--tags", "--always"
+        standardOutput = stdout
+    }
+
+    def longTag = stdout.toString().trim()
+    println("Parsing tag - $longTag")
+    if (longTag.contains('-')) {
+        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    } else {
+        return longTag
+    }
+}

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -9,8 +9,8 @@ tasks.withType(Test) {
 }
 
 task jacocoTestReport(
-        type: JacocoReport,
-        group: "verification"
+    type: JacocoReport,
+    group: "verification"
 ) {
     reports {
         xml.enabled = true
@@ -24,7 +24,7 @@ task jacocoTestReport(
     getSourceDirectories().setFrom(files([mainSrc]))
     getClassDirectories().setFrom(files([debugTree]))
     getExecutionData().setFrom(fileTree(dir: project.buildDir, includes: [
-            "jacoco/testDebugUnitTest.exec",
-            "outputs/code-coverage/connected/*coverage.ec"
+        "jacoco/testDebugUnitTest.exec",
+        "outputs/code-coverage/connected/*coverage.ec"
     ]))
 }


### PR DESCRIPTION
Move some of the code from the projects build.gradle file out into different gradle files, making it a bit cleaner and more to the point