### PR TITLE
ci: split up the android ci file into multiple

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,49 @@
+name: Master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run assemble
+      run: ./gradlew assemble
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run testDebugUnitTest
+      run: ./gradlew testDebugUnitTest
+    - name: run jacocoTestReport
+      run: ./gradlew jacocoTestReport
+    - uses: codecov/codecov-action@v1.0.14
+
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run lintDebug
+      run: ./gradlew app:lintDebug
+    - name: run detekt
+      run: ./gradlew detekt
+    - name: upload linting results
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint
+        path: build/reports/

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -1,15 +1,28 @@
-name: Android CI
+name: Pre Merge
 
 on:
-  push:
-    branches: [ master ]
   pull_request_target:
-    branches: [ master ]
+    branches: [ '*' ]
 
 jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 0
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 1.8
+    - name: run assemble
+      run: ./gradlew assemble
+
   test:
-   runs-on: ubuntu-latest
-   steps:
+    runs-on: ubuntu-latest
+    steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{github.event.pull_request.head.ref}}


### PR DESCRIPTION
Instead of just 'android' which ran everything on master and for all PRs, split up the files based
on if they are building master or a pull request. This cleans it up a little bit and makes it
slightly easier to update in the future