### PR TITLE
chore: remove preferences dependency that wasn't using ktx

### DIFF
--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-    implementation "androidx.preference:preference:$preferences_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"
     implementation "com.chesire:lifecyklelog:$lifecykle_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"


### PR DESCRIPTION
We already added the ktx dependency, so adding the default one without is not required and instead
produces a lint warning