### PR TITLE
chore: remove debug manifest that was unused

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome">
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-</manifest>


### PR DESCRIPTION
Manifest was only trying to provide the external storage permission, but this is unable to be used
when we are targeting android 10+, so remove the manifest completely