### PR TITLE
ci: update the pre-merge ci action to run Danger manually

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -72,6 +72,7 @@ jobs:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
+    
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.3
       with:
@@ -79,24 +80,29 @@ jobs:
     - uses: actions/setup-ruby@v1.1.2
       with:
         ruby-version: '2.6'
+
     - name: install bundler 2.1.4
       run: gem install bundler:2.1.4
+
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
         restore-keys: |
           ${{ runner.os }}-gems-
+
     - name: download lint results
       uses: actions/download-artifact@v2
       with:
         name: lint
         path: build/reports/
-    - uses: MeilCli/danger-action@v5.0.0
-      with:
-        plugins_file: 'Gemfile'
-        install_path: 'vendor/bundle'
-        danger_file: 'Dangerfile'
-        danger_id: 'danger-ci'
+        
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --without=documentation --jobs 4 --retry 3
+
+    - name: danger
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_API_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+      run: bundle exec danger


### PR DESCRIPTION
The Danger github action being used is not working, due to it setting an environment variable, which
is no longer supported on GitHub Actions. For now change it to just run Danger manually