### PR TITLE
chore: make all test dependencies share dependency versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,9 +125,9 @@ dependencies {
     debugImplementation "com.squareup.leakcanary:leakcanary-android:2.5"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     androidTestImplementation project(path: ":testing")
@@ -141,7 +141,7 @@ dependencies {
         exclude group: "com.android.support"
         exclude group: "org.jetbrains.kotlin"
     }
-    androidTestImplementation "io.mockk:mockk-android:1.10.2"
+    androidTestImplementation "io.mockk:mockk-android:$mockk_version"
 
     kapt "androidx.hilt:hilt-compiler:$hiltx_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ task clean(type: Delete) {
 ext {
     sdk_version = 30
 
+    // App
     appcompat_version = "1.2.0"
     coil_version = "1.1.0"
     constraint_layout_version = "2.0.4"
@@ -61,6 +62,11 @@ ext {
     retrofit_version = "2.9.0"
     room_version = "2.2.5"
     timber_version = "4.7.1"
+
+    // Tests
+    coretesting_version = "2.1.0"
+    junit_version = "4.13.1"
+    mockk_version = "1.10.2"
 }
 
 apply from: "detekt.gradle"

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -58,9 +58,9 @@ dependencies {
     implementation "io.coil-kt:coil:$coil_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "androidx.hilt:hilt-compiler:$hiltx_version"

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     implementation "io.coil-kt:coil:$coil_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -58,9 +58,9 @@ dependencies {
     implementation "io.coil-kt:coil:$coil_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     implementation "io.coil-kt:coil:$coil_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     kapt "androidx.hilt:hilt-compiler:$hiltx_version"

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation "io.coil-kt:coil:$coil_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation "com.mikepenz:aboutlibraries:$aboutlibraries_version"
     implementation "com.mikepenz:aboutlibraries-definitions:$aboutlibraries_version"
 
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "junit:junit:$junit_version"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
     androidTestImplementation "androidx.test.ext:junit:1.1.2"

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"
 
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "junit:junit:$junit_version"
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
     androidTestImplementation "androidx.test.ext:junit:1.1.2"

--- a/libraries/account/build.gradle
+++ b/libraries/account/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 }

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshi_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
 

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "junit:junit:$junit_version"
 
     androidTestImplementation project(path: ":testing")
     androidTestImplementation "androidx.room:room-testing:$room_version"

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"

--- a/libraries/kitsu/library/build.gradle
+++ b/libraries/kitsu/library/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/kitsu/search/build.gradle
+++ b/libraries/kitsu/search/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/kitsu/trending/build.gradle
+++ b/libraries/kitsu/trending/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/kitsu/user/build.gradle
+++ b/libraries/kitsu/user/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     testImplementation project(path: ":testing")
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/library/build.gradle
+++ b/libraries/library/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "io.mockk:mockk:1.10.2"
-    testImplementation "junit:junit:4.13.1"
+    testImplementation "androidx.arch.core:core-testing:$coretesting_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -30,6 +30,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
-    implementation "junit:junit:4.13.1"
+    implementation "junit:junit:$junit_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 }


### PR DESCRIPTION
All usages of junit and mockk are hard coded into each of the gradle files, change them all to
instead use a variable from the project build.gradle