### PR TITLE
refactor: remove various unused dto params

### DIFF
--- a/features/search/src/test/java/com/chesire/nekome/app/search/SearchDomainMapperTests.kt
+++ b/features/search/src/test/java/com/chesire/nekome/app/search/SearchDomainMapperTests.kt
@@ -34,7 +34,6 @@ class SearchDomainMapperTests {
             "slug",
             "synopsis",
             "canonicalTitle",
-            "averageRating",
             "startDate",
             "endDate",
             Subtype.Manhua,

--- a/features/search/src/test/java/com/chesire/nekome/app/search/SearchViewModelTests.kt
+++ b/features/search/src/test/java/com/chesire/nekome/app/search/SearchViewModelTests.kt
@@ -205,7 +205,6 @@ class SearchViewModelTests {
             "slug",
             "synopsis",
             "canonicalTitle",
-            "0",
             "startDate",
             "endDate",
             Subtype.Unknown,

--- a/libraries/kitsu/auth/src/main/java/com/chesire/nekome/kitsu/auth/dto/AuthResponseDto.kt
+++ b/libraries/kitsu/auth/src/main/java/com/chesire/nekome/kitsu/auth/dto/AuthResponseDto.kt
@@ -10,14 +10,6 @@ import com.squareup.moshi.JsonClass
 data class AuthResponseDto(
     @Json(name = "access_token")
     val accessToken: String,
-    @Json(name = "created_at")
-    val createdAt: Long,
-    @Json(name = "expires_in")
-    val expiresIn: Long,
     @Json(name = "refresh_token")
-    val refreshToken: String,
-    @Json(name = "scope")
-    val scope: String,
-    @Json(name = "token_type")
-    val tokenType: String
+    val refreshToken: String
 )

--- a/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
+++ b/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
@@ -116,8 +116,7 @@ class KitsuAuthTests {
     fun `login successful response with body returns Resource#Success`() = runBlocking {
         val usernameInput = "username"
         val passwordInput = "password"
-        val loginResponse =
-            AuthResponseDto("accessToken", 0, 0, "refreshToken", "scope", "tokenType")
+        val loginResponse = AuthResponseDto("accessToken", "refreshToken")
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = any() } just Runs
@@ -150,7 +149,7 @@ class KitsuAuthTests {
         val passwordInput = "password"
         val expected = "expectedAccessToken"
         val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto(expected, 0, 0, "refreshToken", "scope", "tokenType")
+        val loginResponse = AuthResponseDto(expected, "refreshToken")
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = capture(slot) } just Runs
@@ -180,7 +179,7 @@ class KitsuAuthTests {
         val passwordInput = "password"
         val expected = "expectedRefreshToken"
         val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto("accessToken", 0, 0, expected, "scope", "tokenType")
+        val loginResponse = AuthResponseDto("accessToken", expected)
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = any() } just Runs
@@ -319,7 +318,7 @@ class KitsuAuthTests {
     @Test
     fun `refresh successful response with body returns Resource#Success`() = runBlocking {
         val loginResponse =
-            AuthResponseDto("accessToken", 0, 0, "refreshToken", "scope", "tokenType")
+            AuthResponseDto("accessToken", "refreshToken")
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = any() } just Runs
@@ -351,7 +350,7 @@ class KitsuAuthTests {
     fun `refresh successful response with body saves an access token`() = runBlocking {
         val expected = "expectedAccessToken"
         val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto(expected, 0, 0, "refreshToken", "scope", "tokenType")
+        val loginResponse = AuthResponseDto(expected, "refreshToken")
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = capture(slot) } just Runs
@@ -380,7 +379,7 @@ class KitsuAuthTests {
     fun `refresh successful response with body saves a refresh token`() = runBlocking {
         val expected = "expectedRefreshToken"
         val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto("accessToken", 0, 0, expected, "scope", "tokenType")
+        val loginResponse = AuthResponseDto("accessToken", expected)
 
         val mockProvider = mockk<AuthProvider> {
             every { accessToken = any() } just Runs

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/DataDto.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/DataDto.kt
@@ -54,8 +54,6 @@ data class DataDto(
              */
             @JsonClass(generateAdapter = true)
             data class RelationshipData(
-                @Json(name = "type")
-                val type: String,
                 @Json(name = "id")
                 val id: Int
             )

--- a/libraries/kitsu/library/src/test/java/com/chesire/nekome/kitsu/library/LibraryCreation.kt
+++ b/libraries/kitsu/library/src/test/java/com/chesire/nekome/kitsu/library/LibraryCreation.kt
@@ -69,14 +69,14 @@ fun createDataDto(type: SeriesType, id: Int = 0) =
         DataDto.Relationships(
             if (type == SeriesType.Anime) {
                 DataDto.Relationships.RelationshipObject(
-                    DataDto.Relationships.RelationshipObject.RelationshipData("", id)
+                    DataDto.Relationships.RelationshipObject.RelationshipData(id)
                 )
             } else {
                 null
             },
             if (type == SeriesType.Manga) {
                 DataDto.Relationships.RelationshipObject(
-                    DataDto.Relationships.RelationshipObject.RelationshipData("", id)
+                    DataDto.Relationships.RelationshipObject.RelationshipData(id)
                 )
             } else {
                 null

--- a/libraries/kitsu/search/src/main/java/com/chesire/nekome/kitsu/search/SearchItemDtoMapper.kt
+++ b/libraries/kitsu/search/src/main/java/com/chesire/nekome/kitsu/search/SearchItemDtoMapper.kt
@@ -19,7 +19,6 @@ class SearchItemDtoMapper @Inject constructor() {
             input.attributes.slug,
             input.attributes.synopsis,
             input.attributes.canonicalTitle,
-            "",
             input.attributes.startDate,
             input.attributes.endDate,
             input.attributes.subtype,

--- a/libraries/kitsu/search/src/main/java/com/chesire/nekome/kitsu/search/dto/SearchResponseDto.kt
+++ b/libraries/kitsu/search/src/main/java/com/chesire/nekome/kitsu/search/dto/SearchResponseDto.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.kitsu.search.dto
 
-import com.chesire.nekome.kitsu.api.intermediaries.Links
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -10,7 +9,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class SearchResponseDto(
     @Json(name = "data")
-    val data: List<SearchItemDto>,
-    @Json(name = "links")
-    val links: Links
+    val data: List<SearchItemDto>
 )

--- a/libraries/kitsu/search/src/test/java/com/chesire/nekome/kitsu/search/KitsuSearchTests.kt
+++ b/libraries/kitsu/search/src/test/java/com/chesire/nekome/kitsu/search/KitsuSearchTests.kt
@@ -103,7 +103,7 @@ class KitsuSearchTests {
 
     @Test
     fun `searchForAnime successful response with body returns Resource#Success`() = runBlocking {
-        val expected = SearchResponseDto(listOf(createSearchItemDto(SeriesType.Anime)), mockk())
+        val expected = SearchResponseDto(listOf(createSearchItemDto(SeriesType.Anime)))
 
         val mockResponse = mockk<Response<SearchResponseDto>> {
             every { isSuccessful } returns true
@@ -228,7 +228,7 @@ class KitsuSearchTests {
 
     @Test
     fun `searchForManga successful response with body returns Resource#Success`() = runBlocking {
-        val expected = SearchResponseDto(listOf(createSearchItemDto(SeriesType.Manga)), mockk())
+        val expected = SearchResponseDto(listOf(createSearchItemDto(SeriesType.Manga)))
 
         val mockResponse = mockk<Response<SearchResponseDto>> {
             every { isSuccessful } returns true

--- a/libraries/kitsu/search/src/test/java/com/chesire/nekome/kitsu/search/SearchItemDtoMapperTests.kt
+++ b/libraries/kitsu/search/src/test/java/com/chesire/nekome/kitsu/search/SearchItemDtoMapperTests.kt
@@ -53,7 +53,6 @@ class SearchItemDtoMapperTests {
         assertEquals(input.attributes.slug, output.slug)
         assertEquals(input.attributes.synopsis, output.synopsis)
         assertEquals(input.attributes.canonicalTitle, output.canonicalTitle)
-        assertEquals("", output.averageRating)
         assertEquals(input.attributes.startDate, output.startDate)
         assertEquals(input.attributes.endDate, output.endDate)
         assertEquals(input.attributes.subtype, output.subtype)

--- a/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
+++ b/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
@@ -19,7 +19,6 @@ class TrendingItemDtoMapper @Inject constructor() {
             input.attributes.slug,
             input.attributes.synopsis,
             input.attributes.canonicalTitle,
-            "",
             input.attributes.startDate,
             input.attributes.endDate,
             input.attributes.subtype,

--- a/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapperTests.kt
+++ b/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapperTests.kt
@@ -53,7 +53,6 @@ class TrendingItemDtoMapperTests {
         assertEquals(input.attributes.slug, output.slug)
         assertEquals(input.attributes.synopsis, output.synopsis)
         assertEquals(input.attributes.canonicalTitle, output.canonicalTitle)
-        assertEquals("", output.averageRating)
         assertEquals(input.attributes.startDate, output.startDate)
         assertEquals(input.attributes.endDate, output.endDate)
         assertEquals(input.attributes.subtype, output.subtype)

--- a/libraries/kitsu/user/src/main/java/com/chesire/nekome/kitsu/user/KitsuUserService.kt
+++ b/libraries/kitsu/user/src/main/java/com/chesire/nekome/kitsu/user/KitsuUserService.kt
@@ -13,6 +13,6 @@ interface KitsuUserService {
      * Gets the details about a user.
      * This requires an auth token set in the header to get the correct user.
      */
-    @GET("api/edge/users?filter[self]=true&fields[users]=id,name,slug,ratingSystem,avatar,coverImage")
+    @GET("api/edge/users?filter[self]=true&fields[users]=id,name,avatar,coverImage")
     suspend fun getUserDetailsAsync(): Response<UserResponseDto>
 }

--- a/libraries/kitsu/user/src/main/java/com/chesire/nekome/kitsu/user/dto/UserItemDto.kt
+++ b/libraries/kitsu/user/src/main/java/com/chesire/nekome/kitsu/user/dto/UserItemDto.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.kitsu.user.dto
 
-import com.chesire.nekome.core.flags.RatingSystem
 import com.chesire.nekome.core.models.ImageModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -22,10 +21,6 @@ data class UserItemDto(
     data class Attributes(
         @Json(name = "name")
         val name: String,
-        @Json(name = "slug")
-        val slug: String?,
-        @Json(name = "ratingSystem")
-        val ratingSystem: RatingSystem,
         @Json(name = "avatar")
         val avatar: ImageModel?,
         @Json(name = "coverImage")

--- a/libraries/kitsu/user/src/test/java/com/chesire/nekome/kitsu/user/KitsuUserTests.kt
+++ b/libraries/kitsu/user/src/test/java/com/chesire/nekome/kitsu/user/KitsuUserTests.kt
@@ -1,7 +1,6 @@
 package com.chesire.nekome.kitsu.user
 
 import com.chesire.nekome.core.Resource
-import com.chesire.nekome.core.flags.RatingSystem
 import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.kitsu.user.dto.UserItemDto
 import com.chesire.nekome.kitsu.user.dto.UserResponseDto
@@ -111,8 +110,6 @@ class KitsuUserTests {
                     0,
                     UserItemDto.Attributes(
                         "name",
-                        "name",
-                        RatingSystem.Unknown,
                         ImageModel.empty,
                         ImageModel.empty
                     )

--- a/libraries/kitsu/user/src/test/java/com/chesire/nekome/kitsu/user/UserItemDtoMapperTests.kt
+++ b/libraries/kitsu/user/src/test/java/com/chesire/nekome/kitsu/user/UserItemDtoMapperTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.kitsu.user
 
-import com.chesire.nekome.core.flags.RatingSystem
 import com.chesire.nekome.core.flags.Service
 import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.kitsu.user.dto.UserItemDto
@@ -30,8 +29,6 @@ class UserItemDtoMapperTests {
             10,
             UserItemDto.Attributes(
                 "name",
-                "slug",
-                RatingSystem.Advanced,
                 avatarImageInput,
                 coverImageInput
             )

--- a/libraries/server/search/src/main/java/com/chesire/nekome/search/api/SearchDomain.kt
+++ b/libraries/server/search/src/main/java/com/chesire/nekome/search/api/SearchDomain.kt
@@ -14,7 +14,6 @@ data class SearchDomain(
     val slug: String,
     val synopsis: String,
     val canonicalTitle: String,
-    val averageRating: String,
     val startDate: String?,
     val endDate: String?,
     val subtype: Subtype,

--- a/libraries/server/trending/src/main/java/com/chesire/nekome/trending/api/TrendingDomain.kt
+++ b/libraries/server/trending/src/main/java/com/chesire/nekome/trending/api/TrendingDomain.kt
@@ -14,7 +14,6 @@ data class TrendingDomain(
     val slug: String,
     val synopsis: String,
     val canonicalTitle: String,
-    val averageRating: String,
     val startDate: String?,
     val endDate: String?,
     val subtype: Subtype,


### PR DESCRIPTION
Throughout development several params have been added to the various DTO and Domain objects and have
just lived there. This removes a bunch of them, with more being removed in the future when it is
refactored to not use the SeriesModel everywhere.