### PR TITLE
refactor: remove series model usage from trending

### DIFF
--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/DiscoverViewModel.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/DiscoverViewModel.kt
@@ -5,32 +5,31 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chesire.nekome.app.discover.domain.DiscoverDomainMapper
+import com.chesire.nekome.app.discover.domain.TrendingModel
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.extensions.postError
 import com.chesire.nekome.core.extensions.postSuccess
 import com.chesire.nekome.core.flags.AsyncState
-import com.chesire.nekome.core.flags.SeriesStatus
-import com.chesire.nekome.core.flags.UserSeriesStatus
-import com.chesire.nekome.core.models.ImageModel
-import com.chesire.nekome.core.models.SeriesModel
 import com.chesire.nekome.trending.api.TrendingApi
-import com.chesire.nekome.trending.api.TrendingDomain
 import kotlinx.coroutines.launch
 
 /**
  * ViewModel to aid with performing series discovery.
  */
 class DiscoverViewModel @ViewModelInject constructor(
-    private val trending: TrendingApi
+    private val trending: TrendingApi,
+    private val mapper: DiscoverDomainMapper
 ) : ViewModel() {
 
     private val _trendingAnime by lazy {
-        val trendingData =
-            MutableLiveData<AsyncState<List<SeriesModel>, DiscoverError>>(AsyncState.Loading())
+        val trendingData = MutableLiveData<AsyncState<List<TrendingModel>, DiscoverError>>(
+            AsyncState.Loading()
+        )
         viewModelScope.launch {
             when (val animeList = trending.getTrendingAnime()) {
                 is Resource.Success -> trendingData.postSuccess(
-                    animeList.data.map { it.toSeriesModel() }
+                    animeList.data.map { mapper.toTrendingModel(it) }
                 )
                 is Resource.Error -> trendingData.postError(DiscoverError.Error)
             }
@@ -39,12 +38,13 @@ class DiscoverViewModel @ViewModelInject constructor(
     }
 
     private val _trendingManga by lazy {
-        val trendingData =
-            MutableLiveData<AsyncState<List<SeriesModel>, DiscoverError>>(AsyncState.Loading())
+        val trendingData = MutableLiveData<AsyncState<List<TrendingModel>, DiscoverError>>(
+            AsyncState.Loading()
+        )
         viewModelScope.launch {
             when (val mangaList = trending.getTrendingManga()) {
                 is Resource.Success -> trendingData.postSuccess(
-                    mangaList.data.map { it.toSeriesModel() }
+                    mangaList.data.map { mapper.toTrendingModel(it) }
                 )
                 is Resource.Error -> trendingData.postError(DiscoverError.Error)
             }
@@ -55,31 +55,12 @@ class DiscoverViewModel @ViewModelInject constructor(
     /**
      * Get the current trending Anime series.
      */
-    val trendingAnime: LiveData<AsyncState<List<SeriesModel>, DiscoverError>>
+    val trendingAnime: LiveData<AsyncState<List<TrendingModel>, DiscoverError>>
         get() = _trendingAnime
 
     /**
      * Get the current trending Manga series.
      */
-    val trendingManga: LiveData<AsyncState<List<SeriesModel>, DiscoverError>>
+    val trendingManga: LiveData<AsyncState<List<TrendingModel>, DiscoverError>>
         get() = _trendingManga
-
-    private fun TrendingDomain.toSeriesModel(): SeriesModel = SeriesModel(
-        id,
-        0,
-        type,
-        subtype,
-        slug,
-        synopsis,
-        canonicalTitle,
-        SeriesStatus.Unknown,
-        UserSeriesStatus.Unknown,
-        0,
-        0,
-        posterImage ?: ImageModel.empty,
-        coverImage ?: ImageModel.empty,
-        nsfw,
-        startDate ?: "",
-        endDate ?: ""
-    )
 }

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/DiscoverDomainMapper.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/DiscoverDomainMapper.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.app.discover.domain
 
-import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.trending.api.TrendingDomain
 import javax.inject.Inject
 
@@ -17,6 +16,6 @@ class DiscoverDomainMapper @Inject constructor() {
             input.id,
             input.type,
             input.canonicalTitle,
-            input.posterImage ?: ImageModel.empty
+            input.posterImage
         )
 }

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/DiscoverDomainMapper.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/DiscoverDomainMapper.kt
@@ -1,0 +1,22 @@
+package com.chesire.nekome.app.discover.domain
+
+import com.chesire.nekome.core.models.ImageModel
+import com.chesire.nekome.trending.api.TrendingDomain
+import javax.inject.Inject
+
+/**
+ * Provides ability to map from instances of [TrendingDomain].
+ */
+class DiscoverDomainMapper @Inject constructor() {
+
+    /**
+     * Converts an instance of [TrendingDomain] into a [TrendingModel].
+     */
+    fun toTrendingModel(input: TrendingDomain) =
+        TrendingModel(
+            input.id,
+            input.type,
+            input.canonicalTitle,
+            input.posterImage ?: ImageModel.empty
+        )
+}

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/TrendingModel.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/TrendingModel.kt
@@ -1,0 +1,29 @@
+package com.chesire.nekome.app.discover.domain
+
+import android.os.Parcelable
+import androidx.recyclerview.widget.DiffUtil
+import com.chesire.nekome.core.flags.SeriesType
+import com.chesire.nekome.core.models.ImageModel
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * Model containing information to show for a trending item.
+ */
+@Parcelize
+data class TrendingModel(
+    val id: Int,
+    val type: SeriesType,
+    val canonicalTitle: String,
+    val posterImage: ImageModel
+) : Parcelable
+
+/**
+ * Provides a [DiffUtil.ItemCallback] class for use with the [TrendingModel].
+ */
+class DiffCallback : DiffUtil.ItemCallback<TrendingModel>() {
+    override fun areItemsTheSame(oldItem: TrendingModel, newItem: TrendingModel) =
+        oldItem.id == newItem.id
+
+    override fun areContentsTheSame(oldItem: TrendingModel, newItem: TrendingModel) =
+        oldItem == newItem
+}

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingAdapter.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingAdapter.kt
@@ -4,12 +4,13 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.chesire.nekome.app.discover.R
-import com.chesire.nekome.core.models.SeriesModel
+import com.chesire.nekome.app.discover.domain.DiffCallback
+import com.chesire.nekome.app.discover.domain.TrendingModel
 
 /**
- * Adapter to aid with displaying the trending items pulled from [TrendingApi].
+ * Adapter to aid with displaying the trending results.
  */
-class TrendingAdapter : ListAdapter<SeriesModel, TrendingViewHolder>(SeriesModel.DiffCallback()) {
+class TrendingAdapter : ListAdapter<TrendingModel, TrendingViewHolder>(DiffCallback()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrendingViewHolder {
         return TrendingViewHolder(
             LayoutInflater.from(parent.context).inflate(

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingViewHolder.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingViewHolder.kt
@@ -3,7 +3,7 @@ package com.chesire.nekome.app.discover.trending
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
-import com.chesire.nekome.core.models.SeriesModel
+import com.chesire.nekome.app.discover.domain.TrendingModel
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.adapter_item_trending.itemTrendingImage
 import kotlinx.android.synthetic.main.adapter_item_trending.itemTrendingTitle
@@ -12,17 +12,17 @@ import kotlinx.android.synthetic.main.adapter_item_trending.itemTrendingTitle
  * ViewHolder for the Trending items in discover.
  */
 class TrendingViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
-    private lateinit var seriesModel: SeriesModel
-    override val containerView: View?
+    private lateinit var trendingModel: TrendingModel
+    override val containerView: View
         get() = itemView
 
     /**
      * Binds the [model] data to the view.
      */
-    fun bind(model: SeriesModel) {
-        seriesModel = model
+    fun bind(model: TrendingModel) {
+        trendingModel = model
 
         itemTrendingImage.load(model.posterImage.smallest?.url)
-        itemTrendingTitle.text = seriesModel.title
+        itemTrendingTitle.text = trendingModel.canonicalTitle
     }
 }

--- a/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
+++ b/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
@@ -1,5 +1,6 @@
 package com.chesire.nekome.kitsu.trending
 
+import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.kitsu.trending.dto.TrendingItemDto
 import com.chesire.nekome.trending.api.TrendingDomain
 import javax.inject.Inject
@@ -23,8 +24,8 @@ class TrendingItemDtoMapper @Inject constructor() {
             input.attributes.endDate,
             input.attributes.subtype,
             input.attributes.status,
-            input.attributes.posterImage,
-            input.attributes.coverImage,
+            input.attributes.posterImage ?: ImageModel.empty,
+            input.attributes.coverImage ?: ImageModel.empty,
             input.attributes.chapterCount,
             input.attributes.episodeCount,
             input.attributes.nsfw

--- a/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
+++ b/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapper.kt
@@ -17,17 +17,7 @@ class TrendingItemDtoMapper @Inject constructor() {
         TrendingDomain(
             input.id,
             input.type,
-            input.attributes.slug,
-            input.attributes.synopsis,
             input.attributes.canonicalTitle,
-            input.attributes.startDate,
-            input.attributes.endDate,
-            input.attributes.subtype,
-            input.attributes.status,
-            input.attributes.posterImage ?: ImageModel.empty,
-            input.attributes.coverImage ?: ImageModel.empty,
-            input.attributes.chapterCount,
-            input.attributes.episodeCount,
-            input.attributes.nsfw
+            input.attributes.posterImage ?: ImageModel.empty
         )
 }

--- a/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/dto/TrendingItemDto.kt
+++ b/libraries/kitsu/trending/src/main/java/com/chesire/nekome/kitsu/trending/dto/TrendingItemDto.kt
@@ -1,8 +1,6 @@
 package com.chesire.nekome.kitsu.trending.dto
 
-import com.chesire.nekome.core.flags.SeriesStatus
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.models.ImageModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -24,29 +22,9 @@ data class TrendingItemDto(
      */
     @JsonClass(generateAdapter = true)
     data class Attributes(
-        @Json(name = "slug")
-        val slug: String,
-        @Json(name = "synopsis")
-        val synopsis: String,
         @Json(name = "canonicalTitle")
         val canonicalTitle: String,
-        @Json(name = "startDate")
-        val startDate: String?,
-        @Json(name = "endDate")
-        val endDate: String?,
-        @Json(name = "subtype")
-        val subtype: Subtype,
-        @Json(name = "status")
-        val status: SeriesStatus,
         @Json(name = "posterImage")
-        val posterImage: ImageModel?,
-        @Json(name = "coverImage")
-        val coverImage: ImageModel?,
-        @Json(name = "chapterCount")
-        val chapterCount: Int?,
-        @Json(name = "episodeCount")
-        val episodeCount: Int?,
-        @Json(name = "nsfw")
-        val nsfw: Boolean = false
+        val posterImage: ImageModel?
     )
 }

--- a/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingCreation.kt
+++ b/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingCreation.kt
@@ -1,8 +1,6 @@
 package com.chesire.nekome.kitsu.trending
 
-import com.chesire.nekome.core.flags.SeriesStatus
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.kitsu.trending.dto.TrendingItemDto
 
@@ -14,17 +12,7 @@ fun createTrendingItemDto(type: SeriesType) =
         0,
         type,
         TrendingItemDto.Attributes(
-            "slug",
-            "synopsis",
             "canonicalTitle",
-            "startDate",
-            "endDate",
-            Subtype.Unknown,
-            SeriesStatus.Unknown,
-            ImageModel.empty,
-            ImageModel.empty,
-            0,
-            0,
-            false
+            ImageModel.empty
         )
     )

--- a/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapperTests.kt
+++ b/libraries/kitsu/trending/src/test/java/com/chesire/nekome/kitsu/trending/TrendingItemDtoMapperTests.kt
@@ -1,8 +1,6 @@
 package com.chesire.nekome.kitsu.trending
 
-import com.chesire.nekome.core.flags.SeriesStatus
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.kitsu.trending.dto.TrendingItemDto
 import com.chesire.nekome.testing.createImageModel
@@ -21,28 +19,12 @@ class TrendingItemDtoMapperTests {
             ImageModel.ImageData("posterMedium", 30, 15),
             ImageModel.ImageData("posterLarge", 40, 20),
         )
-        val coverImageInput = createImageModel(
-            ImageModel.ImageData("coverTiny", 5, 10),
-            ImageModel.ImageData("coverSmall", 10, 20),
-            ImageModel.ImageData("coverMedium", 15, 30),
-            ImageModel.ImageData("coverLarge", 20, 40),
-        )
         val input = TrendingItemDto(
             10,
             SeriesType.Anime,
             TrendingItemDto.Attributes(
-                "slug",
-                "synopsis",
                 "canonicalTitle",
-                "startDate",
-                "endDate",
-                Subtype.Movie,
-                SeriesStatus.Upcoming,
-                posterImageInput,
-                coverImageInput,
-                0,
-                11,
-                true
+                posterImageInput
             )
         )
 
@@ -50,17 +32,7 @@ class TrendingItemDtoMapperTests {
 
         assertEquals(input.id, output.id)
         assertEquals(input.type, output.type)
-        assertEquals(input.attributes.slug, output.slug)
-        assertEquals(input.attributes.synopsis, output.synopsis)
         assertEquals(input.attributes.canonicalTitle, output.canonicalTitle)
-        assertEquals(input.attributes.startDate, output.startDate)
-        assertEquals(input.attributes.endDate, output.endDate)
-        assertEquals(input.attributes.subtype, output.subtype)
-        assertEquals(input.attributes.status, output.status)
         assertEquals(input.attributes.posterImage, output.posterImage)
-        assertEquals(input.attributes.coverImage, output.coverImage)
-        assertEquals(input.attributes.chapterCount, output.chapterCount)
-        assertEquals(input.attributes.episodeCount, output.episodeCount)
-        assertEquals(input.attributes.nsfw, output.nsfw)
     }
 }

--- a/libraries/server/trending/src/main/java/com/chesire/nekome/trending/api/TrendingDomain.kt
+++ b/libraries/server/trending/src/main/java/com/chesire/nekome/trending/api/TrendingDomain.kt
@@ -1,8 +1,6 @@
 package com.chesire.nekome.trending.api
 
-import com.chesire.nekome.core.flags.SeriesStatus
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.models.ImageModel
 
 /**
@@ -11,16 +9,6 @@ import com.chesire.nekome.core.models.ImageModel
 data class TrendingDomain(
     val id: Int,
     val type: SeriesType,
-    val slug: String,
-    val synopsis: String,
     val canonicalTitle: String,
-    val startDate: String?,
-    val endDate: String?,
-    val subtype: Subtype,
-    val status: SeriesStatus,
-    val posterImage: ImageModel?,
-    val coverImage: ImageModel?,
-    val chapterCount: Int?,
-    val episodeCount: Int?,
-    val nsfw: Boolean = false
+    val posterImage: ImageModel
 )


### PR DESCRIPTION
Remove usage of the SeriesModel from the Discover module, and reduce the amount of information pulled from the TrendingApi as it isn't required.