### PR TITLE
refactor: remove various unused params from the series interaction

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,15 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/app/src/androidTest/java/com/chesire/nekome/flow/series/SeriesViewHolderTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/flow/series/SeriesViewHolderTests.kt
@@ -250,15 +250,12 @@ class SeriesViewHolderTests {
                     SeriesType.Anime,
                     Subtype.TV,
                     "slug",
-                    "synopsis",
                     "title",
                     SeriesStatus.Current,
                     UserSeriesStatus.Current,
                     2,
                     3,
                     ImageModel.empty,
-                    ImageModel.empty,
-                    false,
                     "",
                     ""
                 )

--- a/app/src/androidTest/java/com/chesire/nekome/helpers/creation/LibraryDomain.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/helpers/creation/LibraryDomain.kt
@@ -17,15 +17,12 @@ fun createLibraryDomain(
     seriesType: SeriesType = SeriesType.Anime,
     subtype: Subtype = Subtype.Unknown,
     slug: String = "slug",
-    synopsis: String = "synopsis",
     title: String = "title",
     seriesStatus: SeriesStatus = SeriesStatus.Unknown,
     userSeriesStatus: UserSeriesStatus = UserSeriesStatus.Unknown,
     progress: Int = 0,
     totalLength: Int = 0,
     posterImage: ImageModel = ImageModel.empty,
-    coverImage: ImageModel = ImageModel.empty,
-    nsfw: Boolean = false,
     startDate: String = "startDate",
     endDate: String = "endDate"
 ) = LibraryDomain(
@@ -34,15 +31,12 @@ fun createLibraryDomain(
     type = seriesType,
     subtype = subtype,
     slug = slug,
-    synopsis = synopsis,
     title = title,
     seriesStatus = seriesStatus,
     userSeriesStatus = userSeriesStatus,
     progress = progress,
     totalLength = totalLength,
     posterImage = posterImage,
-    coverImage = coverImage,
-    nsfw = nsfw,
     startDate = startDate,
     endDate = endDate
 )

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibraryService.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibraryService.kt
@@ -13,9 +13,9 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 private const val ANIME_FIELDS =
-    "slug,synopsis,canonicalTitle,startDate,endDate,subtype,status,posterImage,coverImage,episodeCount,nsfw"
+    "slug,canonicalTitle,startDate,endDate,subtype,status,posterImage,episodeCount"
 private const val MANGA_FIELDS =
-    "slug,synopsis,canonicalTitle,startDate,endDate,subtype,status,posterImage,coverImage,chapterCount"
+    "slug,canonicalTitle,startDate,endDate,subtype,status,posterImage,chapterCount"
 
 /**
  * Constructed using Retrofit to interface with the Kitsu API for queries related to users library.

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/ResponseDtoMapper.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/ResponseDtoMapper.kt
@@ -34,15 +34,12 @@ class ResponseDtoMapper @Inject constructor() {
             included.type,
             included.attributes.subtype,
             included.attributes.slug,
-            included.attributes.synopsis,
             included.attributes.canonicalTitle,
             included.attributes.status,
             data.attributes.status,
             data.attributes.progress,
             included.attributes.episodeCount ?: included.attributes.chapterCount ?: 0,
             included.attributes.posterImage ?: ImageModel.empty,
-            included.attributes.coverImage ?: ImageModel.empty,
-            included.attributes.nsfw,
             included.attributes.startDate ?: "",
             included.attributes.endDate ?: ""
         )

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/IncludedDto.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/IncludedDto.kt
@@ -26,8 +26,6 @@ data class IncludedDto(
     data class Attributes(
         @Json(name = "slug")
         val slug: String,
-        @Json(name = "synopsis")
-        val synopsis: String,
         @Json(name = "canonicalTitle")
         val canonicalTitle: String,
         @Json(name = "startDate")
@@ -40,13 +38,9 @@ data class IncludedDto(
         val status: SeriesStatus,
         @Json(name = "posterImage")
         val posterImage: ImageModel?,
-        @Json(name = "coverImage")
-        val coverImage: ImageModel?,
         @Json(name = "chapterCount")
         val chapterCount: Int?,
         @Json(name = "episodeCount")
-        val episodeCount: Int?,
-        @Json(name = "nsfw")
-        val nsfw: Boolean = false
+        val episodeCount: Int?
     )
 }

--- a/libraries/kitsu/library/src/test/java/com/chesire/nekome/kitsu/library/LibraryCreation.kt
+++ b/libraries/kitsu/library/src/test/java/com/chesire/nekome/kitsu/library/LibraryCreation.kt
@@ -22,15 +22,12 @@ fun createLibraryDomain() =
         SeriesType.Anime,
         Subtype.Unknown,
         "slug",
-        "synopsis",
         "title",
         SeriesStatus.Unknown,
         UserSeriesStatus.Unknown,
         0,
         0,
         ImageModel.empty,
-        ImageModel.empty,
-        false,
         "startDate",
         "endDate"
     )
@@ -92,32 +89,26 @@ fun createIncludedDto(
     type: SeriesType,
     id: Int = 0,
     slug: String = "slug",
-    synopsis: String = "synopsis",
     canonicalTitle: String = "canonicalTitle",
     startDate: String = "startDate",
     endDate: String = "endDate",
     subtype: Subtype = Subtype.Unknown,
     seriesStatus: SeriesStatus = SeriesStatus.Unknown,
     posterImage: ImageModel = ImageModel.empty,
-    coverImage: ImageModel = ImageModel.empty,
     chapterCount: Int = 0,
-    episodeCount: Int = 0,
-    nsfw: Boolean = false
+    episodeCount: Int = 0
 ) = IncludedDto(
     id,
     type,
     IncludedDto.Attributes(
         slug,
-        synopsis,
         canonicalTitle,
         startDate,
         endDate,
         subtype,
         seriesStatus,
         posterImage,
-        coverImage,
         chapterCount,
-        episodeCount,
-        nsfw
+        episodeCount
     )
 )

--- a/libraries/library/src/test/java/com/chesire/nekome/library/LibraryDomainMapperTests.kt
+++ b/libraries/library/src/test/java/com/chesire/nekome/library/LibraryDomainMapperTests.kt
@@ -22,15 +22,12 @@ class LibraryDomainMapperTests {
             SeriesType.Manga,
             Subtype.Manhwa,
             "slug",
-            "synopsis",
             "title",
             SeriesStatus.Upcoming,
             UserSeriesStatus.Planned,
             0,
             12,
             ImageModel.empty,
-            ImageModel.empty,
-            false,
             "startDate",
             "endDate"
         )

--- a/libraries/library/src/test/java/com/chesire/nekome/library/SeriesRepositoryTests.kt
+++ b/libraries/library/src/test/java/com/chesire/nekome/library/SeriesRepositoryTests.kt
@@ -349,15 +349,12 @@ class SeriesRepositoryTests {
             SeriesType.Anime,
             Subtype.Unknown,
             "slug",
-            "synopsis",
             "title",
             SeriesStatus.Unknown,
             UserSeriesStatus.Unknown,
             0,
             0,
             ImageModel.empty,
-            ImageModel.empty,
-            false,
             "startDate",
             "endDate"
         )

--- a/libraries/server/library/src/main/java/com/chesire/nekome/library/api/LibraryDomain.kt
+++ b/libraries/server/library/src/main/java/com/chesire/nekome/library/api/LibraryDomain.kt
@@ -15,15 +15,12 @@ data class LibraryDomain(
     val type: SeriesType,
     val subtype: Subtype,
     val slug: String,
-    val synopsis: String,
     val title: String,
     val seriesStatus: SeriesStatus,
     val userSeriesStatus: UserSeriesStatus,
     val progress: Int,
     val totalLength: Int,
     val posterImage: ImageModel,
-    val coverImage: ImageModel,
-    val nsfw: Boolean,
     val startDate: String,
     val endDate: String
 )


### PR DESCRIPTION
When communicating with the series endpoints, more data was being pulled down than needed such as
the synopsis, this can be removed from the api calls to save on bandwidth and storage