### PR TITLE
refactor: remove deprecated kotlin gradle plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.application"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
@@ -34,9 +33,6 @@ android {
         buildTypes.each {
             it.resValue("string", "version", defaultConfig.versionName)
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/app/src/main/java/com/chesire/nekome/Activity.kt
+++ b/app/src/main/java/com/chesire/nekome/Activity.kt
@@ -26,7 +26,6 @@ import com.chesire.nekome.core.settings.ApplicationSettings
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.activity.activityDrawer
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -46,12 +45,14 @@ class Activity : AppCompatActivity(), AuthCaster.AuthCasterListener, Flow {
 
     private val viewModel by viewModels<ActivityViewModel>()
 
+    private lateinit var activityDrawer: DrawerLayout
     private lateinit var appBarConfiguration: AppBarConfiguration
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.AppTheme_NoActionBar)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity)
+        activityDrawer = findViewById(R.id.activityDrawer)
         setSupportActionBar(findViewById(R.id.appBarToolbar))
         setupNavController()
         observeViewModel()

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
+    id "kotlin-parcelize"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
 }
@@ -22,9 +22,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-    androidExtensions {
-        experimental true
     }
     kotlinOptions {
         jvmTarget = "1.8"

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -23,6 +23,9 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    buildFeatures {
+        viewBinding true
+    }
     kotlinOptions {
         jvmTarget = "1.8"
     }

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/TrendingModel.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/domain/TrendingModel.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import androidx.recyclerview.widget.DiffUtil
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.models.ImageModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model containing information to show for a trending item.

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingAdapter.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingAdapter.kt
@@ -3,7 +3,7 @@ package com.chesire.nekome.app.discover.trending
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import com.chesire.nekome.app.discover.R
+import com.chesire.nekome.app.discover.databinding.AdapterItemTrendingBinding
 import com.chesire.nekome.app.discover.domain.DiffCallback
 import com.chesire.nekome.app.discover.domain.TrendingModel
 
@@ -13,8 +13,8 @@ import com.chesire.nekome.app.discover.domain.TrendingModel
 class TrendingAdapter : ListAdapter<TrendingModel, TrendingViewHolder>(DiffCallback()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrendingViewHolder {
         return TrendingViewHolder(
-            LayoutInflater.from(parent.context).inflate(
-                R.layout.adapter_item_trending,
+            AdapterItemTrendingBinding.inflate(
+                LayoutInflater.from(parent.context),
                 parent,
                 false
             )

--- a/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingViewHolder.kt
+++ b/features/discover/src/main/java/com/chesire/nekome/app/discover/trending/TrendingViewHolder.kt
@@ -1,20 +1,18 @@
 package com.chesire.nekome.app.discover.trending
 
-import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.chesire.nekome.app.discover.databinding.AdapterItemTrendingBinding
 import com.chesire.nekome.app.discover.domain.TrendingModel
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.adapter_item_trending.itemTrendingImage
-import kotlinx.android.synthetic.main.adapter_item_trending.itemTrendingTitle
 
 /**
  * ViewHolder for the Trending items in discover.
  */
-class TrendingViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
+class TrendingViewHolder(
+    private val binding: AdapterItemTrendingBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
     private lateinit var trendingModel: TrendingModel
-    override val containerView: View
-        get() = itemView
 
     /**
      * Binds the [model] data to the view.
@@ -22,7 +20,7 @@ class TrendingViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutCont
     fun bind(model: TrendingModel) {
         trendingModel = model
 
-        itemTrendingImage.load(model.posterImage.smallest?.url)
-        itemTrendingTitle.text = trendingModel.canonicalTitle
+        binding.itemTrendingImage.load(model.posterImage.smallest?.url)
+        binding.itemTrendingTitle.text = trendingModel.canonicalTitle
     }
 }

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
@@ -22,9 +21,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
 }
@@ -21,9 +20,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
+    id "kotlin-parcelize"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
 }
@@ -22,9 +22,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/features/search/src/main/java/com/chesire/nekome/app/search/domain/SearchModel.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/domain/SearchModel.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.DiffUtil
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.models.ImageModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model containing information to show for a searched item.

--- a/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsAdapter.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsAdapter.kt
@@ -3,7 +3,7 @@ package com.chesire.nekome.app.search.results
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import com.chesire.nekome.app.search.R
+import com.chesire.nekome.app.search.databinding.ItemResultBinding
 import com.chesire.nekome.app.search.domain.DiffCallback
 import com.chesire.nekome.app.search.domain.SearchModel
 
@@ -25,7 +25,7 @@ class ResultsAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResultsViewHolder {
         return ResultsViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.item_result, parent, false)
+            ItemResultBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         ).apply {
             bindListener(resultsListener)
         }

--- a/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewHolder.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewHolder.kt
@@ -1,28 +1,22 @@
 package com.chesire.nekome.app.search.results
 
-import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.chesire.nekome.app.search.R
+import com.chesire.nekome.app.search.databinding.ItemResultBinding
 import com.chesire.nekome.app.search.domain.SearchModel
 import com.chesire.nekome.core.extensions.hide
 import com.chesire.nekome.core.extensions.show
 import com.chesire.nekome.core.extensions.visibleIf
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.item_result.resultDescription
-import kotlinx.android.synthetic.main.item_result.resultImage
-import kotlinx.android.synthetic.main.item_result.resultProgressBar
-import kotlinx.android.synthetic.main.item_result.resultSubType
-import kotlinx.android.synthetic.main.item_result.resultTitle
-import kotlinx.android.synthetic.main.item_result.resultTrack
 
 /**
  * ViewHolder to be used with the [ResultsAdapter].
  */
-class ResultsViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
+class ResultsViewHolder(
+    private val binding: ItemResultBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
     private lateinit var searchModel: SearchModel
-    override val containerView: View
-        get() = itemView
 
     /**
      * Bind the [model] to the view to display data.
@@ -30,22 +24,29 @@ class ResultsViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutConta
     fun bind(model: SearchModel, exists: Boolean) {
         searchModel = model
 
+        binding.apply {
+            resultTitle.text = model.canonicalTitle
+            resultDescription.text = model.synopsis
+            resultSubType.text = model.subtype.name
+
+            resultTrack.visibleIf { !exists }
+            resultLayout.alpha = if (exists) 0.3f else 1f
+        }
+
+        loadResultImage(model)
+    }
+
+    private fun loadResultImage(model: SearchModel) = binding.apply {
         resultImage.load(model.posterImage.smallest?.url) {
             placeholder(R.drawable.ic_insert_photo)
             error(R.drawable.ic_insert_photo)
         }
-        resultTitle.text = model.canonicalTitle
-        resultDescription.text = model.synopsis
-        resultSubType.text = model.subtype.name
-
-        resultTrack.visibleIf { !exists }
-        containerView.alpha = if (exists) 0.3f else 1f
     }
 
     /**
      * Bind the [ResultsListener] to the [ResultsViewHolder] so click events can be collected.
      */
-    fun bindListener(resultsListener: ResultsListener) {
+    fun bindListener(resultsListener: ResultsListener) = binding.apply {
         resultTrack.setOnClickListener {
             startTrackingSeries()
             resultsListener.onTrack(searchModel) {
@@ -54,12 +55,12 @@ class ResultsViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutConta
         }
     }
 
-    private fun startTrackingSeries() {
+    private fun startTrackingSeries() = binding.apply {
         resultTrack.hide()
         resultProgressBar.show()
     }
 
-    private fun finishTrackingSeries() {
+    private fun finishTrackingSeries() = binding.apply {
         resultProgressBar.hide()
     }
 }

--- a/features/search/src/main/res/layout/item_result.xml
+++ b/features/search/src/main/res/layout/item_result.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/resultLayout"
     android:layout_width="match_parent"
     android:layout_height="113dp"
     android:layout_marginStart="8dp"

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
+    id "kotlin-parcelize"
     id "dagger.hilt.android.plugin"
 }
 
@@ -21,9 +21,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesAdapter.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesAdapter.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.chesire.nekome.app.series.R
 import com.chesire.nekome.app.series.SeriesPreferences
+import com.chesire.nekome.app.series.databinding.AdapterItemSeriesBinding
 import com.chesire.nekome.app.series.list.SeriesInteractionListener
 import com.chesire.nekome.core.flags.SortOption
 import com.chesire.nekome.library.SeriesDomain
@@ -67,7 +67,7 @@ class SeriesAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeriesViewHolder {
         return SeriesViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.adapter_item_series, parent, false)
+            AdapterItemSeriesBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         ).apply {
             bindListener(listener)
         }

--- a/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesViewHolder.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesViewHolder.kt
@@ -1,9 +1,9 @@
 package com.chesire.nekome.app.series.list.view
 
-import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.chesire.nekome.app.series.R
+import com.chesire.nekome.app.series.databinding.AdapterItemSeriesBinding
 import com.chesire.nekome.app.series.list.SeriesInteractionListener
 import com.chesire.nekome.app.series.list.lengthKnown
 import com.chesire.nekome.core.extensions.hide
@@ -11,22 +11,15 @@ import com.chesire.nekome.core.extensions.show
 import com.chesire.nekome.core.extensions.toAlpha
 import com.chesire.nekome.core.extensions.visibleIf
 import com.chesire.nekome.library.SeriesDomain
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.adapter_item_series.seriesDate
-import kotlinx.android.synthetic.main.adapter_item_series.seriesImage
-import kotlinx.android.synthetic.main.adapter_item_series.seriesPlusOne
-import kotlinx.android.synthetic.main.adapter_item_series.seriesProgress
-import kotlinx.android.synthetic.main.adapter_item_series.seriesProgressBar
-import kotlinx.android.synthetic.main.adapter_item_series.seriesSubtype
-import kotlinx.android.synthetic.main.adapter_item_series.seriesTitle
 
 /**
  * ViewHolder for Series items in the Anime or Manga list.
  */
-class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
+class SeriesViewHolder(
+    private val binding: AdapterItemSeriesBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
     private lateinit var series: SeriesDomain
-    override val containerView: View
-        get() = itemView
 
     /**
      * Binds the [model] data to the view.
@@ -34,44 +27,53 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
     fun bind(model: SeriesDomain) {
         series = model
 
-        seriesImage.load(model.posterImage.smallest?.url) {
+        binding.apply {
+            seriesTitle.text = model.canonicalTitle
+            seriesSubtype.text = model.subtype.name
+            seriesProgress.text = seriesProgress.context.getString(
+                R.string.series_list_length,
+                model.progress.toString(),
+                if (model.lengthKnown) model.totalLength else '-'
+            )
+            seriesPlusOne.visibleIf(invisible = true) {
+                !model.lengthKnown || model.progress < model.totalLength
+            }
+        }
+
+        loadSeriesImage(model)
+        loadDateString(model)
+    }
+
+    private fun loadSeriesImage(model: SeriesDomain) {
+        binding.seriesImage.load(model.posterImage.smallest?.url) {
             placeholder(R.drawable.ic_insert_photo)
             error(R.drawable.ic_insert_photo)
         }
-        seriesTitle.text = model.canonicalTitle
-        seriesSubtype.text = model.subtype.name
-        seriesProgress.text = containerView.context.getString(
-            R.string.series_list_length,
-            model.progress.toString(),
-            if (model.lengthKnown) model.totalLength else '-'
-        )
-        setupDateString(model)
-        seriesPlusOne.visibleIf(invisible = true) {
-            !model.lengthKnown || model.progress < model.totalLength
-        }
     }
 
-    private fun setupDateString(model: SeriesDomain) {
-        val dateString = with(containerView.context) {
-            when {
-                model.startDate.isEmpty() && model.endDate.isEmpty() -> getString(R.string.series_list_unknown)
-                model.startDate == model.endDate -> model.startDate
-                model.endDate.isEmpty() -> getString(
-                    R.string.series_list_date_range,
-                    model.startDate,
-                    getString(R.string.series_list_ongoing)
-                )
-                else -> getString(R.string.series_list_date_range, model.startDate, model.endDate)
-            }
+    private fun loadDateString(model: SeriesDomain) = binding.seriesDate.apply {
+        text = when {
+            model.startDate.isEmpty() && model.endDate.isEmpty() ->
+                context.getString(R.string.series_list_unknown)
+            model.startDate == model.endDate -> model.startDate
+            model.endDate.isEmpty() -> context.getString(
+                R.string.series_list_date_range,
+                model.startDate,
+                context.getString(R.string.series_list_ongoing)
+            )
+            else -> context.getString(
+                R.string.series_list_date_range,
+                model.startDate,
+                model.endDate
+            )
         }
-        seriesDate.text = dateString
     }
 
     /**
      * Binds the [listener] to the view.
      */
-    fun bindListener(listener: SeriesInteractionListener) {
-        containerView.setOnClickListener {
+    fun bindListener(listener: SeriesInteractionListener) = binding.apply {
+        seriesLayout.setOnClickListener {
             listener.seriesSelected(
                 seriesImage,
                 series
@@ -85,13 +87,13 @@ class SeriesViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContai
         }
     }
 
-    private fun startUpdatingSeries() {
+    private fun startUpdatingSeries() = binding.apply {
         seriesProgressBar.show()
         seriesPlusOne.isEnabled = false
         seriesPlusOne.toAlpha(0.3f)
     }
 
-    private fun finishUpdatingSeries() {
+    private fun finishUpdatingSeries() = binding.apply {
         seriesProgressBar.hide()
         seriesPlusOne.isEnabled = true
         seriesPlusOne.toAlpha(1f)

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
 }
@@ -21,9 +20,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-    androidExtensions {
-        experimental true
     }
     buildFeatures {
         viewBinding true

--- a/libraries/account/build.gradle
+++ b/libraries/account/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
+    id "kotlin-parcelize"
 }
 
 android {
@@ -27,9 +27,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-    androidExtensions {
-        experimental true
     }
 }
 

--- a/libraries/core/src/main/java/com/chesire/nekome/core/models/ImageModel.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/models/ImageModel.kt
@@ -2,7 +2,7 @@ package com.chesire.nekome.core.models
 
 import android.os.Parcelable
 import com.squareup.moshi.JsonClass
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Data for images.

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/library/build.gradle
+++ b/libraries/kitsu/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/search/build.gradle
+++ b/libraries/kitsu/search/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/trending/build.gradle
+++ b/libraries/kitsu/trending/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/kitsu/user/build.gradle
+++ b/libraries/kitsu/user/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/library/build.gradle
+++ b/libraries/library/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.library"
     id "kotlin-android"
     id "kotlin-kapt"
+    id "kotlin-parcelize"
 }
 
 android {

--- a/libraries/library/build.gradle
+++ b/libraries/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
     id "kotlin-kapt"
 }
 

--- a/libraries/library/src/main/java/com/chesire/nekome/library/SeriesDomain.kt
+++ b/libraries/library/src/main/java/com/chesire/nekome/library/SeriesDomain.kt
@@ -6,7 +6,7 @@ import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.ImageModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Domain object for a single Series item.

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "kotlin-android-extensions"
 }
 
 android {


### PR DESCRIPTION
Remove the `kotlin-android-extensions` plugin. 
This completely removes synthetics from the project.