### PR TITLE
refactor: remove usage of reflection in the KitsuLibrary

### DIFF
--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibrary.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibrary.kt
@@ -15,7 +15,6 @@ import okhttp3.MediaType
 import okhttp3.RequestBody
 import retrofit2.Response
 import javax.inject.Inject
-import kotlin.reflect.KSuspendFunction3
 
 private const val LIMIT = 500
 private const val MAX_RETRIES = 3
@@ -116,11 +115,7 @@ class KitsuLibrary @Inject constructor(
     @Suppress("ComplexMethod", "LongMethod")
     private suspend fun performRetrieveCall(
         userId: Int,
-        execute: KSuspendFunction3<
-            @ParameterName(name = "userId") Int,
-            @ParameterName(name = "offset") Int,
-            @ParameterName(name = "limit") Int,
-            Response<RetrieveResponseDto>>
+        execute: suspend (userId: Int, offset: Int, limit: Int) -> Response<RetrieveResponseDto>
     ): Resource<List<LibraryDomain>> {
         val models = mutableListOf<LibraryDomain>()
 


### PR DESCRIPTION
KitsuLibrary was using reflection via a KSuspendFunction to invoke one of two methods passed in.
This could be changed to a lambda to have the same effect without needing to use reflection.

Closes #396 