### PR TITLE
fix: force a user logout if the refresh token is invalid

### DIFF
--- a/features/series/src/main/java/com/chesire/nekome/app/series/list/SeriesListViewModel.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/list/SeriesListViewModel.kt
@@ -77,7 +77,11 @@ class SeriesListViewModel @ViewModelInject constructor(
         )
 
         if (syncCommands.any { it is Resource.Error }) {
-            _refreshStatus.postError(Any())
+            if (syncCommands.any { it is Resource.Error && it.code == Resource.Error.CouldNotRefresh }) {
+                authCaster.issueRefreshingToken()
+            } else {
+                _refreshStatus.postError(Any())
+            }
         } else {
             _refreshStatus.postSuccess(Any())
         }


### PR DESCRIPTION
In other parts of the application we are forcing the user to be logged out if the token is invalid,
but it was missed in the SeriesList, now if the user tries to refresh the series and their token is
invalid it will log them out.

Fixes #452 