### PR TITLE
refactor: update interceptor to globally handle invalid auth

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -127,7 +127,6 @@ empty-blocks:
 
 exceptions:
   active: true
-  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
   ExceptionRaisedInUnexpectedLocation:
     active: true
     methodNames: 'toString,hashCode,equals,finalize'

--- a/detekt.yml
+++ b/detekt.yml
@@ -127,6 +127,7 @@ empty-blocks:
 
 exceptions:
   active: true
+  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
   ExceptionRaisedInUnexpectedLocation:
     active: true
     methodNames: 'toString,hashCode,equals,finalize'

--- a/features/search/src/main/java/com/chesire/nekome/app/search/SearchViewModel.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/SearchViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.app.search.domain.SearchDomainMapper
 import com.chesire.nekome.app.search.domain.SearchModel
-import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.extensions.postError
 import com.chesire.nekome.core.extensions.postLoading
@@ -23,7 +22,6 @@ import kotlinx.coroutines.launch
  */
 class SearchViewModel @ViewModelInject constructor(
     private val searchApi: SearchApi,
-    private val authCaster: AuthCaster,
     private val mapper: SearchDomainMapper
 ) : ViewModel() {
 
@@ -64,11 +62,6 @@ class SearchViewModel @ViewModelInject constructor(
             } else {
                 _searchResult.postSuccess(response.data.map { mapper.toSearchModel(it) })
             }
-        is Resource.Error ->
-            if (response.code == Resource.Error.CouldNotRefresh) {
-                authCaster.issueRefreshingToken()
-            } else {
-                _searchResult.postError(SearchError.GenericError)
-            }
+        is Resource.Error -> _searchResult.postError(SearchError.GenericError)
     }
 }

--- a/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/results/ResultsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.settings.ApplicationSettings
@@ -17,7 +16,6 @@ import kotlinx.coroutines.launch
  */
 class ResultsViewModel @ViewModelInject constructor(
     private val seriesRepo: SeriesRepository,
-    private val authCaster: AuthCaster,
     private val settings: ApplicationSettings
 ) : ViewModel() {
 
@@ -48,10 +46,6 @@ class ResultsViewModel @ViewModelInject constructor(
             else -> error("Unknown SeriesType: ${data.type}")
         }
 
-        if (response is Resource.Error && response.code == Resource.Error.CouldNotRefresh) {
-            authCaster.issueRefreshingToken()
-        } else {
-            callback(response is Resource.Success)
-        }
+        callback(response is Resource.Success)
     }
 }

--- a/features/search/src/test/java/com/chesire/nekome/app/search/SearchViewModelTests.kt
+++ b/features/search/src/test/java/com/chesire/nekome/app/search/SearchViewModelTests.kt
@@ -4,7 +4,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.chesire.nekome.app.search.domain.SearchDomainMapper
 import com.chesire.nekome.app.search.domain.SearchModel
-import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.flags.AsyncState
 import com.chesire.nekome.core.flags.SeriesType
@@ -20,12 +19,12 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
 class SearchViewModelTests {
+
     @get:Rule
     val taskExecutorRule = InstantTaskExecutorRule()
 
@@ -38,11 +37,10 @@ class SearchViewModelTests {
     fun `executeSearch with empty title posts error`() {
         val observerSlot = slot<AsyncState<List<SearchModel>, SearchError>>()
         val mockSearch = mockk<SearchApi>()
-        val mockCaster = mockk<AuthCaster>()
         val mockObserver = mockk<Observer<AsyncState<List<SearchModel>, SearchError>>> {
             every { onChanged(capture(observerSlot)) } just Runs
         }
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.searchResult.observeForever(mockObserver)
         testObject.executeSearch(SearchData("", SeriesType.Anime))
@@ -55,11 +53,10 @@ class SearchViewModelTests {
     fun `executeSearch with unknown seriesType posts error`() {
         val observerSlot = slot<AsyncState<List<SearchModel>, SearchError>>()
         val mockSearch = mockk<SearchApi>()
-        val mockCaster = mockk<AuthCaster>()
         val mockObserver = mockk<Observer<AsyncState<List<SearchModel>, SearchError>>> {
             every { onChanged(capture(observerSlot)) } just Runs
         }
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.searchResult.observeForever(mockObserver)
         testObject.executeSearch(SearchData("New Title", SeriesType.Unknown))
@@ -77,8 +74,7 @@ class SearchViewModelTests {
                 Resource.Error("")
             }
         }
-        val mockCaster = mockk<AuthCaster>()
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.executeSearch(SearchData("title", SeriesType.Anime))
 
@@ -94,8 +90,7 @@ class SearchViewModelTests {
                 Resource.Error("")
             }
         }
-        val mockCaster = mockk<AuthCaster>()
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.executeSearch(SearchData("title", SeriesType.Manga))
 
@@ -115,8 +110,7 @@ class SearchViewModelTests {
                 Resource.Success(emptyList())
             }
         }
-        val mockCaster = mockk<AuthCaster>()
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.searchResult.observeForever(mockObserver)
         testObject.executeSearch(SearchData("title", SeriesType.Anime))
@@ -139,8 +133,7 @@ class SearchViewModelTests {
                 Resource.Success(listOf(createSearchDomain()))
             }
         }
-        val mockCaster = mockk<AuthCaster>()
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.searchResult.observeForever(mockObserver)
         testObject.executeSearch(SearchData("title", SeriesType.Anime))
@@ -163,8 +156,7 @@ class SearchViewModelTests {
                 Resource.Error("")
             }
         }
-        val mockCaster = mockk<AuthCaster>()
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
+        val testObject = SearchViewModel(mockSearch, map)
 
         testObject.searchResult.observeForever(mockObserver)
         testObject.executeSearch(SearchData("title", SeriesType.Anime))
@@ -172,30 +164,6 @@ class SearchViewModelTests {
         coVerify { mockSearch.searchForAnime(any()) }
         assertTrue(observerSlot.isCaptured)
         assertTrue(observerSlot.captured is AsyncState.Error)
-    }
-
-    @Test
-    fun `executeSearch on CouldNotRefresh failure posts to AuthCaster`() {
-        val observerSlot = slot<AsyncState<List<SearchModel>, SearchError>>()
-        val mockObserver = mockk<Observer<AsyncState<List<SearchModel>, SearchError>>> {
-            every { onChanged(capture(observerSlot)) } just Runs
-        }
-        val mockSearch = mockk<SearchApi> {
-            coEvery {
-                searchForAnime(any())
-            } coAnswers {
-                Resource.Error("", Resource.Error.CouldNotRefresh)
-            }
-        }
-        val mockCaster = mockk<AuthCaster> {
-            every { issueRefreshingToken() } just Runs
-        }
-        val testObject = SearchViewModel(mockSearch, mockCaster, map)
-
-        testObject.searchResult.observeForever(mockObserver)
-        testObject.executeSearch(SearchData("title", SeriesType.Anime))
-
-        verify { mockCaster.issueRefreshingToken() }
     }
 
     private fun createSearchDomain() =

--- a/features/search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
+++ b/features/search/src/test/java/com/chesire/nekome/app/search/results/ResultsViewModelTests.kt
@@ -1,23 +1,21 @@
 package com.chesire.nekome.app.search.results
 
-import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.settings.ApplicationSettings
 import com.chesire.nekome.library.SeriesRepository
 import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Rule
 import org.junit.Test
 
 class ResultsViewModelTests {
+
     @get:Rule
     val coroutineRule = CoroutinesMainDispatcherRule()
 
@@ -31,11 +29,10 @@ class ResultsViewModelTests {
             }
             every { getSeries() } returns mockk()
         }
-        val mockCaster = mockk<AuthCaster>()
         val mockSettings = mockk<ApplicationSettings> {
             every { defaultSeriesState } returns UserSeriesStatus.Current
         }
-        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
+        val testObject = ResultsViewModel(mockRepo, mockSettings)
 
         testObject.trackNewSeries(ResultsData(0, SeriesType.Anime)) {}
 
@@ -52,38 +49,14 @@ class ResultsViewModelTests {
             }
             every { getSeries() } returns mockk()
         }
-        val mockCaster = mockk<AuthCaster>()
         val mockSettings = mockk<ApplicationSettings> {
             every { defaultSeriesState } returns UserSeriesStatus.Current
         }
-        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
+        val testObject = ResultsViewModel(mockRepo, mockSettings)
 
         testObject.trackNewSeries(ResultsData(0, SeriesType.Manga)) {}
 
         coVerify { mockRepo.addManga(any(), any()) }
-    }
-
-    @Test
-    fun `trackNewSeries on failure to add and could not refresh fires authCaster`() {
-        val mockRepo = mockk<SeriesRepository> {
-            coEvery {
-                addManga(any(), any())
-            } coAnswers {
-                Resource.Error("", Resource.Error.CouldNotRefresh)
-            }
-            every { getSeries() } returns mockk()
-        }
-        val mockCaster = mockk<AuthCaster> {
-            every { issueRefreshingToken() } just Runs
-        }
-        val mockSettings = mockk<ApplicationSettings> {
-            every { defaultSeriesState } returns UserSeriesStatus.Current
-        }
-        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
-
-        testObject.trackNewSeries(ResultsData(0, SeriesType.Manga)) {}
-
-        verify { mockCaster.issueRefreshingToken() }
     }
 
     @Test
@@ -96,12 +69,11 @@ class ResultsViewModelTests {
             }
             every { getSeries() } returns mockk()
         }
-        val mockCaster = mockk<AuthCaster>()
         val mockCallback = mockk<(Boolean) -> Unit>(relaxed = true)
         val mockSettings = mockk<ApplicationSettings> {
             every { defaultSeriesState } returns UserSeriesStatus.Current
         }
-        val testObject = ResultsViewModel(mockRepo, mockCaster, mockSettings)
+        val testObject = ResultsViewModel(mockRepo, mockSettings)
 
         testObject.trackNewSeries(ResultsData(0, SeriesType.Anime), mockCallback)
 

--- a/features/series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailViewModel.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/detail/SeriesDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.IOContext
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.extensions.postError
@@ -27,7 +26,6 @@ const val MODEL_ID = "SeriesDetail_seriesDomain"
 class SeriesDetailViewModel @ViewModelInject constructor(
     @Assisted private val savedStateHandle: SavedStateHandle,
     private val repo: SeriesRepository,
-    private val authCaster: AuthCaster,
     @IOContext private val ioContext: CoroutineContext
 ) : ViewModel() {
 
@@ -51,9 +49,7 @@ class SeriesDetailViewModel @ViewModelInject constructor(
                 target.seriesProgress,
                 target.userSeriesStatus
             )
-            if (response is Resource.Error && response.code == Resource.Error.CouldNotRefresh) {
-                authCaster.issueRefreshingToken()
-            } else if (response is Resource.Error) {
+            if (response is Resource.Error) {
                 _updatingStatus.postError(
                     target,
                     SeriesDetailError.Error

--- a/libraries/core/src/main/java/com/chesire/nekome/core/Resource.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/Resource.kt
@@ -1,5 +1,10 @@
 package com.chesire.nekome.core
 
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_UNAVAILABLE
+
 /**
  * Generic class to aid with receiving responses.
  */
@@ -18,47 +23,33 @@ sealed class Resource<T> {
     /**
      * Response was a failure, with the [msg] & [code] containing information on why.
      */
-    class Error<T>(val msg: String, val code: Int = GenericError) : Resource<T>() {
+    class Error<T>(val msg: String, val code: Int = HTTP_BAD_REQUEST) : Resource<T>() {
         /**
          * Mutates this instance of [Error] of type [T] into an [Error] of type [U].
          */
         fun <U> mutate() = Error<U>(msg, code)
 
         companion object {
-            /**
-             * Generic error.
-             */
-            const val GenericError = 200
 
             /**
-             * Empty body() object.
+             * Creates an [Error] for a bad request.
              */
-            const val EmptyBody = 204
-
-            /**
-             * Could not refresh the access token.
-             */
-            const val CouldNotRefresh = 401
-
-            /**
-             * Unable to reach the server.
-             */
-            const val CouldNotReach = 503
+            fun <T> badRequest(body: String): Error<T> = Error(body, HTTP_BAD_REQUEST)
 
             /**
              * Creates an [Error] for an empty response.
              */
-            fun <T> emptyResponse(): Error<T> = Error("Response body is null", EmptyBody)
+            fun <T> emptyResponse(): Error<T> = Error("Response body is null", HTTP_NO_CONTENT)
 
             /**
              * Creates an [Error] for invalid auth.
              */
-            fun <T> invalidAuth(): Error<T> = Error("Auth provided is not valid", CouldNotRefresh)
+            fun <T> couldNotRefresh(): Error<T> = Error("Could not refresh auth", HTTP_FORBIDDEN)
 
             /**
              * Creates an [Error] for being unable to reach the server.
              */
-            fun <T> couldNotReach(): Error<T> = Error("Could not reach service", CouldNotReach)
+            fun <T> couldNotReach(): Error<T> = Error("Could not reach service", HTTP_UNAVAILABLE)
         }
     }
 }

--- a/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/AuthException.kt
+++ b/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/AuthException.kt
@@ -1,0 +1,9 @@
+package com.chesire.nekome.kitsu
+
+import java.io.IOException
+
+/**
+ * Exception thrown when the auth token is unable to be refreshed.
+ */
+class AuthException : IOException()
+// IOException must be extended or the Retrofit interceptors will crash

--- a/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
+++ b/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
@@ -44,9 +44,9 @@ fun <T, U> Response<T>.asError() = Resource.Error<U>(
  * Parses out the [Exception] providing a [Resource] for use elsewhere.
  */
 fun <T> Exception.parse(): Resource.Error<T> {
-    return if (this is UnknownHostException) {
-        Resource.Error.couldNotReach()
-    } else {
-        Resource.Error(toString(), 400)
+    return when (this) {
+        is UnknownHostException -> Resource.Error.couldNotReach()
+        is AuthException -> Resource.Error.couldNotRefresh()
+        else -> Resource.Error.badRequest(toString())
     }
 }

--- a/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptor.kt
+++ b/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptor.kt
@@ -1,11 +1,14 @@
 package com.chesire.nekome.kitsu.interceptors
 
 import com.chesire.nekome.auth.api.AuthApi
+import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
+import com.chesire.nekome.kitsu.AuthException
 import com.chesire.nekome.kitsu.AuthProvider
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.net.HttpURLConnection
 import javax.inject.Inject
 
 /**
@@ -20,13 +23,15 @@ import javax.inject.Inject
  */
 class AuthRefreshInterceptor @Inject constructor(
     private val provider: AuthProvider,
-    private val auth: AuthApi
+    private val auth: AuthApi,
+    private val authCaster: AuthCaster
 ) : Interceptor {
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val originRequest = chain.request()
         val response = chain.proceed(originRequest)
 
-        return if (!response.isSuccessful && response.code() == 403) {
+        return if (!response.isSuccessful && response.code() == HttpURLConnection.HTTP_FORBIDDEN) {
             val authResponse = runBlocking { auth.refresh() }
             if (authResponse is Resource.Success) {
                 chain.proceed(
@@ -36,21 +41,11 @@ class AuthRefreshInterceptor @Inject constructor(
                         .build()
                 )
             } else {
-                generateFailureResponse(response)
+                authCaster.issueRefreshingToken()
+                throw AuthException()
             }
         } else {
             response
         }
-    }
-
-    private fun generateFailureResponse(originResponse: Response): Response {
-        // If there is an unrecoverable auth failure report a 401 error for the app to logout with
-        return Response
-            .Builder()
-            .request(originResponse.request())
-            .protocol(originResponse.protocol())
-            .code(401)
-            .message(originResponse.message())
-            .build()
     }
 }

--- a/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptor.kt
+++ b/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptor.kt
@@ -18,8 +18,8 @@ import javax.inject.Inject
  * done as an interceptor instead as the official way expects a 401 to be returned if auth fails,
  * but Kitsu returns a 403 which won't work.
  *
- * If we still cannot refresh the token after attempting here, force a 401 to be returned back to
- * the calling layer and let that handle it.
+ * If we still cannot refresh the token after attempting here, notify the [AuthCaster] so it can
+ * tell any listeners of the failure.
  */
 class AuthRefreshInterceptor @Inject constructor(
     private val provider: AuthProvider,

--- a/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
+++ b/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
@@ -16,7 +16,9 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class AuthRefreshInterceptorTests {
@@ -99,7 +101,7 @@ class AuthRefreshInterceptorTests {
     }
 
     @Test(expected = AuthException::class)
-    fun `getting new auth failure, throws AuthException`(): Unit = runBlocking {
+    fun `getting new auth failure, throws AuthException`() = runBlocking {
         val mockProvider = mockk<AuthProvider>()
         val mockAuth = mockk<AuthApi> {
             coEvery {
@@ -125,6 +127,8 @@ class AuthRefreshInterceptorTests {
         val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
 
         testObject.intercept(mockChain)
+
+        fail("Exception not thrown")
     }
 
     @Test

--- a/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
+++ b/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 
+@Suppress("SwallowedException")
 class AuthRefreshInterceptorTests {
 
     @Test
@@ -91,7 +92,7 @@ class AuthRefreshInterceptorTests {
 
         try {
             testObject.intercept(mockChain)
-        } catch (ex: Exception) {
+        } catch (ex: AuthException) {
             // Ignore the crash
         }
 

--- a/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
+++ b/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/interceptors/AuthRefreshInterceptorTests.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test

--- a/libraries/library/src/main/java/com/chesire/nekome/library/SeriesRepository.kt
+++ b/libraries/library/src/main/java/com/chesire/nekome/library/SeriesRepository.kt
@@ -30,7 +30,7 @@ class SeriesRepository(
     suspend fun addAnime(seriesId: Int, startingStatus: UserSeriesStatus): Resource<SeriesDomain> {
         val idResult = userProvider.provideUserId()
         if (idResult !is UserProvider.UserIdResult.Success) {
-            return Resource.Error.invalidAuth()
+            return Resource.Error.couldNotRefresh()
         }
 
         val response = libraryApi.addAnime(
@@ -57,7 +57,7 @@ class SeriesRepository(
     suspend fun addManga(seriesId: Int, startingStatus: UserSeriesStatus): Resource<SeriesDomain> {
         val idResult = userProvider.provideUserId()
         if (idResult !is UserProvider.UserIdResult.Success) {
-            return Resource.Error.invalidAuth()
+            return Resource.Error.couldNotRefresh()
         }
 
         val response = libraryApi.addManga(
@@ -99,7 +99,7 @@ class SeriesRepository(
     suspend fun refreshAnime(): Resource<List<SeriesDomain>> {
         val idResult = userProvider.provideUserId()
         if (idResult !is UserProvider.UserIdResult.Success) {
-            return Resource.Error.invalidAuth()
+            return Resource.Error.couldNotRefresh()
         }
 
         return when (val response = libraryApi.retrieveAnime(idResult.id)) {
@@ -121,7 +121,7 @@ class SeriesRepository(
     suspend fun refreshManga(): Resource<List<SeriesDomain>> {
         val idResult = userProvider.provideUserId()
         if (idResult !is UserProvider.UserIdResult.Success) {
-            return Resource.Error.invalidAuth()
+            return Resource.Error.couldNotRefresh()
         }
 
         return when (val response = libraryApi.retrieveManga(idResult.id)) {


### PR DESCRIPTION
Update the interceptor so when it attempts to update the auth token, if it fails it will now notify
the AuthCaster itself, instead of passing the error back down to the view models to handle