### PR TITLE
fix: proguard causing runtime crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,4 +18,10 @@
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
+
 #-renamesourcefileattribute SourceFile
+
+# Keep Parcelable and Serializable classes as they are required by the navigation component.
+# https://developer.android.com/guide/navigation/navigation-pass-data#use_keepnames_rules
+-keepnames class * extends android.os.Parcelable
+-keepnames class * extends java.io.Serializable


### PR DESCRIPTION
Some of the new domain classes were causing an issue at runtime because the navigation component was
trying to use them, but the obfuscation would cause it to fail. The documentation states to add them
to the proguard file, so go with that to fix them