### PR TITLE
test: use robolectric to run the database tests

### DIFF
--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -34,13 +34,16 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     sourceSets {
-        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
+        test.assets.srcDirs += files("$projectDir/schemas".toString())
     }
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
+    implementation project(":libraries:core")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
@@ -52,13 +55,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
+    testImplementation project(":testing")
+    testImplementation "androidx.room:room-testing:$room_version"
     testImplementation "junit:junit:$junit_version"
-
-    androidTestImplementation project(path: ":testing")
-    androidTestImplementation "androidx.room:room-testing:$room_version"
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
-    androidTestImplementation "androidx.test:rules:1.3.0"
-    androidTestImplementation "io.mockk:mockk-android:1.10.6"
+    testImplementation "org.robolectric:robolectric:4.4"
 
     kapt "androidx.room:room-compiler:$room_version"
 }

--- a/libraries/database/src/test/java/com/chesire/nekome/database/MigrationTests.kt
+++ b/libraries/database/src/test/java/com/chesire/nekome/database/MigrationTests.kt
@@ -2,10 +2,10 @@ package com.chesire.nekome.database
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
+import android.os.Build
 import androidx.room.Room
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.core.Is
@@ -14,9 +14,12 @@ import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.IOException
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class MigrationTests {
     private val testDB = "migration-test"
 

--- a/libraries/database/src/test/java/com/chesire/nekome/database/dao/SeriesDaoTests.kt
+++ b/libraries/database/src/test/java/com/chesire/nekome/database/dao/SeriesDaoTests.kt
@@ -1,23 +1,22 @@
 package com.chesire.nekome.database.dao
 
+import android.os.Build
 import androidx.room.Room
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.chesire.nekome.core.flags.SeriesStatus
 import com.chesire.nekome.core.flags.SeriesType
-import com.chesire.nekome.core.flags.Subtype
-import com.chesire.nekome.core.flags.UserSeriesStatus
-import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.database.RoomDB
-import com.chesire.nekome.database.entity.SeriesEntity
+import com.chesire.nekome.testing.createSeriesEntity
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class SeriesDaoTests {
     private lateinit var db: RoomDB
     private lateinit var seriesDao: SeriesDao
@@ -29,6 +28,7 @@ class SeriesDaoTests {
                 InstrumentationRegistry.getInstrumentation().context,
                 RoomDB::class.java
             )
+            .allowMainThreadQueries()
             .fallbackToDestructiveMigration()
             .build()
             .also {
@@ -121,12 +121,12 @@ class SeriesDaoTests {
     fun retrieveGetsAllCurrentItemsBasedOnType() = runBlocking {
         seriesDao.insert(
             listOf(
-                createSeriesEntity(id = 0, type = SeriesType.Anime),
-                createSeriesEntity(id = 1, type = SeriesType.Manga),
-                createSeriesEntity(id = 2, type = SeriesType.Anime),
-                createSeriesEntity(id = 3, type = SeriesType.Manga),
-                createSeriesEntity(id = 4, type = SeriesType.Anime),
-                createSeriesEntity(id = 5, type = SeriesType.Manga)
+                createSeriesEntity(id = 0, seriesType = SeriesType.Anime),
+                createSeriesEntity(id = 1, seriesType = SeriesType.Manga),
+                createSeriesEntity(id = 2, seriesType = SeriesType.Anime),
+                createSeriesEntity(id = 3, seriesType = SeriesType.Manga),
+                createSeriesEntity(id = 4, seriesType = SeriesType.Anime),
+                createSeriesEntity(id = 5, seriesType = SeriesType.Manga)
             )
         )
         assertTrue(seriesDao.retrieve().count() == 6)
@@ -140,25 +140,4 @@ class SeriesDaoTests {
         seriesDao.update(createSeriesEntity(id = 0, userId = 1))
         assertTrue(seriesDao.retrieve().first().userId == 1)
     }
-
-    private fun createSeriesEntity(
-        id: Int = 0,
-        userId: Int = 0,
-        type: SeriesType = SeriesType.Unknown
-    ) = SeriesEntity(
-        id,
-        userId,
-        type,
-        Subtype.Unknown,
-        "slug",
-        "title",
-        SeriesStatus.Unknown,
-        UserSeriesStatus.Unknown,
-        0,
-        0,
-        0,
-        ImageModel.empty,
-        "",
-        ""
-    )
 }

--- a/libraries/database/src/test/java/com/chesire/nekome/database/dao/UserDaoTests.kt
+++ b/libraries/database/src/test/java/com/chesire/nekome/database/dao/UserDaoTests.kt
@@ -1,7 +1,7 @@
 package com.chesire.nekome.database.dao
 
+import android.os.Build
 import androidx.room.Room
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.nekome.core.flags.Service
 import com.chesire.nekome.core.models.ImageModel
@@ -15,8 +15,11 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class UserDaoTests {
     private lateinit var db: RoomDB
     private lateinit var userDao: UserDao
@@ -28,6 +31,7 @@ class UserDaoTests {
                 InstrumentationRegistry.getInstrumentation().context,
                 RoomDB::class.java
             )
+            .allowMainThreadQueries()
             .fallbackToDestructiveMigration()
             .build()
             .also {


### PR DESCRIPTION
Instead of running the tests using a real device/emulator, run them on the jvm using robolectric.
This should speed them up, and allow us to get code coverage for the database classes and migrations.

Closes #487 