### PR TITLE
chore: remove the path part of project dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,29 +54,29 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":features:discover")
-    implementation project(path: ":features:login")
-    implementation project(path: ":features:profile")
-    implementation project(path: ":features:search")
-    implementation project(path: ":features:series")
-    implementation project(path: ":features:settings")
-    implementation project(path: ":features:timeline")
-    implementation project(path: ":libraries:account")
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:database")
-    implementation project(path: ":libraries:encryption")
-    implementation project(path: ":libraries:kitsu")
-    implementation project(path: ":libraries:kitsu:auth")
-    implementation project(path: ":libraries:kitsu:library")
-    implementation project(path: ":libraries:kitsu:search")
-    implementation project(path: ":libraries:kitsu:trending")
-    implementation project(path: ":libraries:kitsu:user")
-    implementation project(path: ":libraries:library")
-    implementation project(path: ":libraries:server:auth")
-    implementation project(path: ":libraries:server:library")
-    implementation project(path: ":libraries:server:search")
-    implementation project(path: ":libraries:server:trending")
-    implementation project(path: ":libraries:server:user")
+    implementation project(":features:discover")
+    implementation project(":features:login")
+    implementation project(":features:profile")
+    implementation project(":features:search")
+    implementation project(":features:series")
+    implementation project(":features:settings")
+    implementation project(":features:timeline")
+    implementation project(":libraries:account")
+    implementation project(":libraries:core")
+    implementation project(":libraries:database")
+    implementation project(":libraries:encryption")
+    implementation project(":libraries:kitsu")
+    implementation project(":libraries:kitsu:auth")
+    implementation project(":libraries:kitsu:library")
+    implementation project(":libraries:kitsu:search")
+    implementation project(":libraries:kitsu:trending")
+    implementation project(":libraries:kitsu:user")
+    implementation project(":libraries:library")
+    implementation project(":libraries:server:auth")
+    implementation project(":libraries:server:library")
+    implementation project(":libraries:server:search")
+    implementation project(":libraries:server:trending")
+    implementation project(":libraries:server:user")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
@@ -110,13 +110,13 @@ dependencies {
 
     debugImplementation "com.squareup.leakcanary:leakcanary-android:2.6"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation project(path: ":testing")
+    androidTestImplementation project(":testing")
     androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
     androidTestImplementation "androidx.test.espresso:espresso-intents:3.3.0"

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -32,9 +32,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:library")
-    implementation project(path: ":libraries:server:trending")
+    implementation project(":libraries:core")
+    implementation project(":libraries:library")
+    implementation project(":libraries:server:trending")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
@@ -51,7 +51,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "io.coil-kt:coil:$coil_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -31,10 +31,10 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:account")
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:library")
-    implementation project(path: ":libraries:server:auth")
+    implementation project(":libraries:account")
+    implementation project(":libraries:core")
+    implementation project(":libraries:library")
+    implementation project(":libraries:server:auth")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
@@ -50,7 +50,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "io.coil-kt:coil:$coil_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:account")
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:library")
+    implementation project(":libraries:account")
+    implementation project(":libraries:core")
+    implementation project(":libraries:library")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
@@ -47,7 +47,7 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     implementation "io.coil-kt:coil:$coil_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -32,9 +32,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:library")
-    implementation project(path: ":libraries:server:search")
+    implementation project(":libraries:core")
+    implementation project(":libraries:library")
+    implementation project(":libraries:server:search")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
@@ -51,7 +51,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "io.coil-kt:coil:$coil_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "io.coil-kt:coil:$coil_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -30,7 +30,7 @@ android {
 dependencies {
     def aboutlibraries_version = "8.8.0"
 
-    implementation project(path: ":libraries:core")
+    implementation project(":libraries:core")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.browser:browser:1.3.0"

--- a/libraries/account/build.gradle
+++ b/libraries/account/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:database")
-    implementation project(path: ":libraries:server:user")
+    implementation project(":libraries:core")
+    implementation project(":libraries:database")
+    implementation project(":libraries:server:user")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
@@ -42,7 +42,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -30,10 +30,10 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:encryption")
-    implementation project(path: ':libraries:kitsu')
-    implementation project(path: ':libraries:server:auth')
+    implementation project(":libraries:core")
+    implementation project(":libraries:encryption")
+    implementation project(':libraries:kitsu')
+    implementation project(':libraries:server:auth')
 
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
@@ -45,7 +45,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:encryption")
-    implementation project(path: ":libraries:server:auth")
+    implementation project(":libraries:core")
+    implementation project(":libraries:encryption")
+    implementation project(":libraries:server:auth")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"
@@ -44,7 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/library/build.gradle
+++ b/libraries/kitsu/library/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ':libraries:kitsu')
-    implementation project(path: ':libraries:server:library')
+    implementation project(":libraries:core")
+    implementation project(':libraries:kitsu')
+    implementation project(':libraries:server:library')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/search/build.gradle
+++ b/libraries/kitsu/search/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ':libraries:kitsu')
-    implementation project(path: ':libraries:server:search')
+    implementation project(":libraries:core")
+    implementation project(':libraries:kitsu')
+    implementation project(':libraries:server:search')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/trending/build.gradle
+++ b/libraries/kitsu/trending/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ':libraries:kitsu')
-    implementation project(path: ':libraries:server:trending')
+    implementation project(":libraries:core")
+    implementation project(':libraries:kitsu')
+    implementation project(':libraries:server:trending')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/kitsu/user/build.gradle
+++ b/libraries/kitsu/user/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ':libraries:kitsu')
-    implementation project(path: ':libraries:server:user')
+    implementation project(":libraries:core")
+    implementation project(':libraries:kitsu')
+    implementation project(':libraries:server:user')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 

--- a/libraries/library/build.gradle
+++ b/libraries/library/build.gradle
@@ -31,9 +31,9 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:database")
-    implementation project(path: ":libraries:server:library")
+    implementation project(":libraries:core")
+    implementation project(":libraries:database")
+    implementation project(":libraries:server:library")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    testImplementation project(path: ":testing")
+    testImplementation project(":testing")
     testImplementation "androidx.arch.core:core-testing:$coretesting_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"

--- a/libraries/server/auth/build.gradle
+++ b/libraries/server/auth/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':libraries:core')
+    implementation project(':libraries:core')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"

--- a/libraries/server/library/build.gradle
+++ b/libraries/server/library/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:core")
+    implementation project(":libraries:core")
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"

--- a/libraries/server/search/build.gradle
+++ b/libraries/server/search/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':libraries:core')
+    implementation project(':libraries:core')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"

--- a/libraries/server/trending/build.gradle
+++ b/libraries/server/trending/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':libraries:core')
+    implementation project(':libraries:core')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"

--- a/libraries/server/user/build.gradle
+++ b/libraries/server/user/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':libraries:core')
+    implementation project(':libraries:core')
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -31,10 +31,10 @@ android {
 }
 
 dependencies {
-    implementation project(path: ":libraries:account")
-    implementation project(path: ":libraries:core")
-    implementation project(path: ":libraries:database")
-    implementation project(path: ":libraries:library")
+    implementation project(":libraries:account")
+    implementation project(":libraries:core")
+    implementation project(":libraries:database")
+    implementation project(":libraries:library")
 
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"


### PR DESCRIPTION
path: isn't needed when defining the project dependencies, so remove it