### PR TITLE
refactor: move auth into datasource

### DIFF
--- a/app/src/androidTest/java/com/chesire/nekome/UITest.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/UITest.kt
@@ -4,10 +4,10 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.chesire.nekome.database.dao.SeriesDao
 import com.chesire.nekome.database.dao.UserDao
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 import com.chesire.nekome.helpers.createTestUser
 import com.chesire.nekome.helpers.login
 import com.chesire.nekome.helpers.logout
-import com.chesire.nekome.kitsu.AuthProvider
 import com.schibsted.spain.barista.rule.cleardata.ClearDatabaseRule
 import com.schibsted.spain.barista.rule.cleardata.ClearPreferencesRule
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/DetailsTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/DetailsTests.kt
@@ -2,7 +2,6 @@ package com.chesire.nekome.features.login
 
 import com.chesire.nekome.R
 import com.chesire.nekome.UITest
-import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.url.UrlHandler
 import com.chesire.nekome.datasource.auth.remote.AuthApi
 import com.chesire.nekome.datasource.auth.remote.AuthResult

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/DetailsTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/DetailsTests.kt
@@ -5,6 +5,7 @@ import com.chesire.nekome.UITest
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.core.url.UrlHandler
 import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.remote.AuthResult
 import com.chesire.nekome.helpers.getResource
 import com.chesire.nekome.injection.AuthModule
 import com.chesire.nekome.injection.UrlModule
@@ -33,7 +34,7 @@ class DetailsTests : UITest() {
     val urlHandler = mockk<UrlHandler>()
 
     @BindValue
-    val userApi = mockk<AuthApi>()
+    val authApi = mockk<AuthApi>()
 
     @Test
     fun emptyUsernameShowsError() {
@@ -64,9 +65,9 @@ class DetailsTests : UITest() {
     @Test
     fun invalidCredentialsShowsError() {
         coEvery {
-            userApi.login("Username", "Password")
+            authApi.login("Username", "Password")
         } coAnswers {
-            Resource.Error("", Resource.Error.InvalidCredentials)
+            AuthResult.InvalidCredentials
         }
 
         launchActivity()
@@ -83,9 +84,9 @@ class DetailsTests : UITest() {
     @Test
     fun failureToLoginShowsError() {
         coEvery {
-            userApi.login("Username", "Password")
+            authApi.login("Username", "Password")
         } coAnswers {
-            Resource.Error("Generic error")
+            AuthResult.BadRequest
         }
 
         launchActivity()

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
@@ -3,6 +3,7 @@ package com.chesire.nekome.features.login
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.Resource
 import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.remote.AuthResult
 import com.chesire.nekome.datasource.series.remote.SeriesApi
 import com.chesire.nekome.datasource.user.remote.UserApi
 import com.chesire.nekome.helpers.creation.createSeriesDomain
@@ -35,7 +36,7 @@ class LoginFlowTests : UITest() {
         coEvery {
             login("Username", "Password")
         } coAnswers {
-            Resource.Success(Any())
+            AuthResult.Success("accessToken", "refreshToken")
         }
     }
 

--- a/app/src/androidTest/java/com/chesire/nekome/helpers/AuthProviderExtensions.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/helpers/AuthProviderExtensions.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.helpers
 
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 
 /**
  * Tells the [AuthProvider] that a user is logged in, used to skip login.

--- a/app/src/main/java/com/chesire/nekome/ActivityViewModel.kt
+++ b/app/src/main/java/com/chesire/nekome/ActivityViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.chesire.nekome.core.IOContext
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import com.chesire.nekome.datasource.user.UserRepository
-import com.chesire.nekome.kitsu.AuthProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
  */
 @HiltViewModel
 class ActivityViewModel @Inject constructor(
-    private val authProvider: AuthProvider,
+    private val repo: AccessTokenRepository,
     private val logoutHandler: LogoutHandler,
     @IOContext private val ioContext: CoroutineContext,
     userRepository: UserRepository
@@ -33,7 +33,7 @@ class ActivityViewModel @Inject constructor(
      * Checks if the user is currently logged in.
      */
     val userLoggedIn: Boolean
-        get() = authProvider.accessToken.isNotEmpty()
+        get() = repo.accessToken.isNotEmpty()
 
     /**
      * Logs the user out and returns the user back to entering the login details. [callback] is

--- a/app/src/main/java/com/chesire/nekome/LogoutHandler.kt
+++ b/app/src/main/java/com/chesire/nekome/LogoutHandler.kt
@@ -1,7 +1,7 @@
 package com.chesire.nekome
 
 import com.chesire.nekome.database.RoomDB
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -9,7 +9,7 @@ import javax.inject.Inject
  * Handles clearing out resources for when a log out occurs.
  */
 class LogoutHandler @Inject constructor(
-    private val authProvider: AuthProvider,
+    private val repo: AccessTokenRepository,
     private val db: RoomDB
 ) {
 
@@ -21,6 +21,6 @@ class LogoutHandler @Inject constructor(
         Timber.d("Clearing database tables")
         db.clearAllTables()
         Timber.d("Clearing auth")
-        authProvider.clearAuth()
+        repo.clear()
     }
 }

--- a/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
@@ -1,8 +1,8 @@
 package com.chesire.nekome.injection
 
-import com.chesire.nekome.kitsu.BuildConfig
 import com.chesire.nekome.datasource.auth.remote.AuthInjectionInterceptor
 import com.chesire.nekome.datasource.auth.remote.AuthRefreshInterceptor
+import com.chesire.nekome.kitsu.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable

--- a/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
@@ -1,8 +1,8 @@
 package com.chesire.nekome.injection
 
 import com.chesire.nekome.kitsu.BuildConfig
-import com.chesire.nekome.kitsu.interceptors.AuthInjectionInterceptor
-import com.chesire.nekome.kitsu.interceptors.AuthRefreshInterceptor
+import com.chesire.nekome.datasource.auth.remote.AuthInjectionInterceptor
+import com.chesire.nekome.datasource.auth.remote.AuthRefreshInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable

--- a/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
+++ b/app/src/main/java/com/chesire/nekome/services/RefreshAuthWorker.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.chesire.nekome.core.Resource
-import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
+import com.chesire.nekome.datasource.auth.AccessTokenResult
 import com.chesire.nekome.datasource.user.UserRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -22,7 +22,7 @@ class RefreshAuthWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val userRepo: UserRepository,
-    private val auth: AuthApi
+    private val auth: AccessTokenRepository
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -34,7 +34,7 @@ class RefreshAuthWorker @AssistedInject constructor(
         }
 
         Timber.i("doWork userId found, beginning to refresh")
-        return if (auth.refresh() is Resource.Error) {
+        return if (auth.refresh() !is AccessTokenResult.Success) {
             Result.retry()
         } else {
             Result.success()

--- a/app/src/test/java/com/chesire/nekome/ActivityViewModelTests.kt
+++ b/app/src/test/java/com/chesire/nekome/ActivityViewModelTests.kt
@@ -1,8 +1,8 @@
 package com.chesire.nekome
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import com.chesire.nekome.datasource.user.UserRepository
-import com.chesire.nekome.kitsu.AuthProvider
 import com.chesire.nekome.testing.CoroutinesMainDispatcherRule
 import io.mockk.Runs
 import io.mockk.every
@@ -26,7 +26,7 @@ class ActivityViewModelTests {
 
     @Test
     fun `userLoggedIn failure returns false`() {
-        val mockAuthProvider = mockk<AuthProvider> {
+        val mockAccessTokenRepository = mockk<AccessTokenRepository> {
             every { accessToken } returns ""
         }
         val mockLogoutHandler = mockk<LogoutHandler>()
@@ -35,7 +35,7 @@ class ActivityViewModelTests {
         }
 
         val classUnderTest = ActivityViewModel(
-            mockAuthProvider,
+            mockAccessTokenRepository,
             mockLogoutHandler,
             testDispatcher,
             mockUserRepository
@@ -46,7 +46,7 @@ class ActivityViewModelTests {
 
     @Test
     fun `userLoggedIn success returns true`() {
-        val mockAuthProvider = mockk<AuthProvider> {
+        val mockAccessTokenRepository = mockk<AccessTokenRepository> {
             every { accessToken } returns "access token"
         }
         val mockLogoutHandler = mockk<LogoutHandler>()
@@ -55,7 +55,7 @@ class ActivityViewModelTests {
         }
 
         val classUnderTest = ActivityViewModel(
-            mockAuthProvider,
+            mockAccessTokenRepository,
             mockLogoutHandler,
             testDispatcher,
             mockUserRepository
@@ -66,7 +66,7 @@ class ActivityViewModelTests {
 
     @Test
     fun `logout tells the logoutHandler to execute`() {
-        val mockAuthProvider = mockk<AuthProvider>()
+        val mockAccessTokenRepository = mockk<AccessTokenRepository>()
         val mockLogoutHandler = mockk<LogoutHandler> {
             every { executeLogout() } just Runs
         }
@@ -75,7 +75,7 @@ class ActivityViewModelTests {
         }
 
         val classUnderTest = ActivityViewModel(
-            mockAuthProvider,
+            mockAccessTokenRepository,
             mockLogoutHandler,
             testDispatcher,
             mockUserRepository
@@ -88,7 +88,7 @@ class ActivityViewModelTests {
 
     @Test
     fun `logout executes callback after logoutHandler`() {
-        val mockAuthProvider = mockk<AuthProvider>()
+        val mockAccessTokenRepository = mockk<AccessTokenRepository>()
         val mockLogoutHandler = mockk<LogoutHandler> {
             every { executeLogout() } just Runs
         }
@@ -98,7 +98,7 @@ class ActivityViewModelTests {
         val mockCallback = mockk<() -> Unit>(relaxed = true)
 
         val classUnderTest = ActivityViewModel(
-            mockAuthProvider,
+            mockAccessTokenRepository,
             mockLogoutHandler,
             testDispatcher,
             mockUserRepository

--- a/app/src/test/java/com/chesire/nekome/LogoutHandlerTests.kt
+++ b/app/src/test/java/com/chesire/nekome/LogoutHandlerTests.kt
@@ -1,7 +1,7 @@
 package com.chesire.nekome
 
 import com.chesire.nekome.database.RoomDB
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -13,14 +13,14 @@ class LogoutHandlerTests {
 
     @Test
     fun `executeLogout clears db`() {
-        val mockAuthProvider = mockk<AuthProvider> {
-            every { clearAuth() } just Runs
+        val mockAccessTokenRepository = mockk<AccessTokenRepository> {
+            every { clear() } just Runs
         }
         val mockDb = mockk<RoomDB> {
             every { clearAllTables() } just Runs
         }
 
-        LogoutHandler(mockAuthProvider, mockDb).run {
+        LogoutHandler(mockAccessTokenRepository, mockDb).run {
             executeLogout()
         }
 
@@ -29,17 +29,17 @@ class LogoutHandlerTests {
 
     @Test
     fun `executeLogout clears authProvider`() {
-        val mockAuthProvider = mockk<AuthProvider> {
-            every { clearAuth() } just Runs
+        val mockAccessTokenRepository = mockk<AccessTokenRepository> {
+            every { clear() } just Runs
         }
         val mockDb = mockk<RoomDB> {
             every { clearAllTables() } just Runs
         }
 
-        LogoutHandler(mockAuthProvider, mockDb).run {
+        LogoutHandler(mockAccessTokenRepository, mockDb).run {
             executeLogout()
         }
 
-        verifyAll { mockAuthProvider.clearAuth() }
+        verifyAll { mockAccessTokenRepository.clear() }
     }
 }

--- a/app/src/test/java/com/chesire/nekome/services/RefreshAuthWorkerTests.kt
+++ b/app/src/test/java/com/chesire/nekome/services/RefreshAuthWorkerTests.kt
@@ -3,8 +3,8 @@ package com.chesire.nekome.services
 import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
-import com.chesire.nekome.core.Resource
-import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
+import com.chesire.nekome.datasource.auth.AccessTokenResult
 import com.chesire.nekome.datasource.user.UserRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -46,15 +46,15 @@ class RefreshAuthWorkerTests {
         val mockUserRepo = mockk<UserRepository> {
             coEvery { retrieveUserId() } coAnswers { 1 }
         }
-        val mockAuthApi = mockk<AuthApi> {
-            coEvery { refresh() } coAnswers { Resource.Success(mockk()) }
+        val mockRepository = mockk<AccessTokenRepository> {
+            coEvery { refresh() } returns AccessTokenResult.Success
         }
-        val testObject = RefreshAuthWorker(mockContext, mockParams, mockUserRepo, mockAuthApi)
+        val testObject = RefreshAuthWorker(mockContext, mockParams, mockUserRepo, mockRepository)
 
         val result = testObject.doWork()
 
         assertEquals(ListenableWorker.Result.success(), result)
-        coVerify(exactly = 1) { mockAuthApi.refresh() }
+        coVerify(exactly = 1) { mockRepository.refresh() }
     }
 
     @Test
@@ -68,14 +68,14 @@ class RefreshAuthWorkerTests {
         val mockUserRepo = mockk<UserRepository> {
             coEvery { retrieveUserId() } coAnswers { 1 }
         }
-        val mockAuthApi = mockk<AuthApi> {
-            coEvery { refresh() } coAnswers { Resource.Error("") }
+        val mockRepository = mockk<AccessTokenRepository> {
+            coEvery { refresh() } returns AccessTokenResult.CommunicationError
         }
-        val testObject = RefreshAuthWorker(mockContext, mockParams, mockUserRepo, mockAuthApi)
+        val testObject = RefreshAuthWorker(mockContext, mockParams, mockUserRepo, mockRepository)
 
         val result = testObject.doWork()
 
         assertEquals(ListenableWorker.Result.retry(), result)
-        coVerify(exactly = 1) { mockAuthApi.refresh() }
+        coVerify(exactly = 1) { mockRepository.refresh() }
     }
 }

--- a/libraries/datasource/auth/build.gradle
+++ b/libraries/datasource/auth/build.gradle
@@ -30,7 +30,17 @@ android {
 
 dependencies {
     implementation project(':libraries:core')
+    implementation project(":libraries:encryption")
 
+    implementation "androidx.core:core-ktx:$corektx_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
+    implementation "com.google.dagger:hilt-android:$hilt_version"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+
+    testImplementation project(":testing")
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "junit:junit:$junit_version"
 }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/AccessTokenRepository.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/AccessTokenRepository.kt
@@ -1,0 +1,67 @@
+package com.chesire.nekome.datasource.auth
+
+import com.chesire.nekome.datasource.auth.local.AuthProvider
+import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.remote.AuthResult
+import javax.inject.Inject
+
+/**
+ * Repository to access and update the users access token.
+ */
+class AccessTokenRepository @Inject constructor(
+    private val authProvider: AuthProvider,
+    private val authApi: AuthApi
+) {
+    /**
+     * Accesses the users current access token.
+     */
+    val accessToken: String get() = authProvider.accessToken
+
+    /**
+     * Performs an async request to log the user in, generating access and refresh tokens.
+     * On success the access and refresh tokens are stored locally.
+     */
+    suspend fun login(username: String, password: String): AccessTokenResult {
+        val response = authApi.login(username, password)
+        if (response is AuthResult.Success) {
+            storeTokens(response.accessToken, response.refreshToken)
+        }
+        return handleResponse(response)
+    }
+
+    /**
+     * Performs an async request to refresh the access tokens.
+     * On success the access and refresh tokens are stored locally.
+     */
+    suspend fun refresh(): AccessTokenResult {
+        val response = authApi.refresh(authProvider.refreshToken)
+        if (response is AuthResult.Success) {
+            storeTokens(response.accessToken, response.refreshToken)
+        }
+        return handleResponse(response)
+    }
+
+    /**
+     * Clears out any locally stored tokens.
+     */
+    fun clear() = authProvider.clearAuth()
+
+    private fun handleResponse(response: AuthResult): AccessTokenResult {
+        return when (response) {
+            is AuthResult.Success -> AccessTokenResult.Success
+            AuthResult.InvalidCredentials -> AccessTokenResult.InvalidCredentials
+            else -> AccessTokenResult.CommunicationError
+        }
+    }
+
+    private fun storeTokens(accessToken: String, refreshToken: String) {
+        authProvider.accessToken = accessToken
+        authProvider.refreshToken = refreshToken
+    }
+}
+
+sealed class AccessTokenResult {
+    object Success : AccessTokenResult()
+    object InvalidCredentials : AccessTokenResult()
+    object CommunicationError : AccessTokenResult()
+}

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/AuthException.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/AuthException.kt
@@ -1,4 +1,4 @@
-package com.chesire.nekome.kitsu
+package com.chesire.nekome.datasource.auth
 
 import java.io.IOException
 

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
@@ -1,4 +1,4 @@
-package com.chesire.nekome.kitsu
+package com.chesire.nekome.datasource.auth.local
 
 import android.content.SharedPreferences
 import androidx.core.content.edit

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthApi.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthApi.kt
@@ -1,7 +1,5 @@
 package com.chesire.nekome.datasource.auth.remote
 
-import com.chesire.nekome.core.Resource
-
 /**
  * Methods relating to authorizing as a user.
  */
@@ -10,15 +8,10 @@ interface AuthApi {
     /**
      * Logs into the service using a [username] and [password], returning the success state.
      */
-    suspend fun login(username: String, password: String): Resource<Any>
+    suspend fun login(username: String, password: String): AuthResult
 
     /**
      * Refreshes any current auth credentials.
      */
-    suspend fun refresh(): Resource<Any>
-
-    /**
-     * Clears out any current auth credentials.
-     */
-    suspend fun clearAuth()
+    suspend fun refresh(refreshToken: String): AuthResult
 }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptor.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptor.kt
@@ -1,16 +1,17 @@
-package com.chesire.nekome.kitsu.interceptors
+package com.chesire.nekome.datasource.auth.remote
 
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 /**
- * Interceptor to push the authorization header into Kitsu requests.
+ * Interceptor to push the authorization header into api requests.
  */
 class AuthInjectionInterceptor @Inject constructor(
     private val provider: AuthProvider
 ) : Interceptor {
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val authenticatedRequest = chain.request()
             .newBuilder()

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptor.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptor.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.datasource.auth.remote
 
-import com.chesire.nekome.datasource.auth.local.AuthProvider
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
@@ -9,13 +9,13 @@ import javax.inject.Inject
  * Interceptor to push the authorization header into api requests.
  */
 class AuthInjectionInterceptor @Inject constructor(
-    private val provider: AuthProvider
+    private val repo: AccessTokenRepository
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val authenticatedRequest = chain.request()
             .newBuilder()
-            .header("Authorization", "Bearer ${provider.accessToken}")
+            .header("Authorization", "Bearer ${repo.accessToken}")
             .build()
 
         return chain.proceed(authenticatedRequest)

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptor.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptor.kt
@@ -1,10 +1,9 @@
-package com.chesire.nekome.kitsu.interceptors
+package com.chesire.nekome.datasource.auth.remote
 
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
-import com.chesire.nekome.datasource.auth.remote.AuthApi
-import com.chesire.nekome.kitsu.AuthException
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.AuthException
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -14,9 +13,9 @@ import javax.inject.Inject
 /**
  * Interceptor to handle refreshing access tokens if required.
  *
- * There is an official way to do this using OkHttp or Retrofit, but unfortunately this has to be
- * done as an interceptor instead as the official way expects a 401 to be returned if auth fails,
- * but Kitsu returns a 403 which won't work.
+ * There is an official way to do this using OkHttp or Retrofit, but unfortunately it has to be done
+ * this way in an interceptor as some apis return a 403, and the official way only works if your api
+ * returns a 403.
  *
  * If we still cannot refresh the token after attempting here, notify the [AuthCaster] so it can
  * tell any listeners of the failure.

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptor.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptor.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
  *
  * There is an official way to do this using OkHttp or Retrofit, but unfortunately it has to be done
  * this way in an interceptor as some apis return a 403, and the official way only works if your api
- * returns a 403.
+ * returns a 401.
  *
  * If we still cannot refresh the token after attempting here, notify the [AuthCaster] so it can
  * tell any listeners of the failure.

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthResult.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/remote/AuthResult.kt
@@ -1,0 +1,9 @@
+package com.chesire.nekome.datasource.auth.remote
+
+sealed class AuthResult {
+    data class Success(val accessToken: String, val refreshToken: String) : AuthResult()
+    object CouldNotReachServer : AuthResult()
+    object InvalidCredentials : AuthResult()
+    object CouldNotRefresh : AuthResult()
+    object BadRequest : AuthResult()
+}

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/AccessTokenRepositoryTest.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/AccessTokenRepositoryTest.kt
@@ -30,11 +30,19 @@ class AccessTokenRepositoryTest {
     @Before
     fun setup() {
         authProvider = mockk(relaxed = true) {
+            every { accessToken } returns ACCESS_TOKEN
             every { refreshToken } returns REFRESH_TOKEN_INPUT
         }
         authApi = mockk()
 
         accessTokenRepository = AccessTokenRepository(authProvider, authApi)
+    }
+
+    @Test
+    fun `accessToken returns from the provider`() {
+        val actual = accessTokenRepository.accessToken
+
+        assertEquals(ACCESS_TOKEN, actual)
     }
 
     @Test

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/AccessTokenRepositoryTest.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/AccessTokenRepositoryTest.kt
@@ -1,0 +1,162 @@
+package com.chesire.nekome.datasource.auth
+
+import com.chesire.nekome.datasource.auth.local.AuthProvider
+import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.auth.remote.AuthResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private const val USERNAME_INPUT = "username"
+private const val PASSWORD_INPUT = "password"
+private const val REFRESH_TOKEN_INPUT = "oldAccessToken"
+private const val ACCESS_TOKEN = "accessToken"
+private const val REFRESH_TOKEN = "refreshToken"
+
+class AccessTokenRepositoryTest {
+
+    private lateinit var authProvider: AuthProvider
+    private lateinit var authApi: AuthApi
+    private lateinit var accessTokenRepository: AccessTokenRepository
+
+    @Before
+    fun setup() {
+        authProvider = mockk(relaxed = true) {
+            every { refreshToken } returns REFRESH_TOKEN_INPUT
+        }
+        authApi = mockk()
+
+        accessTokenRepository = AccessTokenRepository(authProvider, authApi)
+    }
+
+    @Test
+    fun `login on success, stores the accessToken`() = runBlocking {
+        coEvery {
+            authApi.login(USERNAME_INPUT, PASSWORD_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        accessTokenRepository.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+        verify { authProvider.accessToken = ACCESS_TOKEN }
+    }
+
+    @Test
+    fun `login on success, stores the refreshToken`() = runBlocking {
+        coEvery {
+            authApi.login(USERNAME_INPUT, PASSWORD_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        accessTokenRepository.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+        verify { authProvider.refreshToken = REFRESH_TOKEN }
+    }
+
+    @Test
+    fun `login on success, returns AccessTokenResult#Success`() = runBlocking {
+        coEvery {
+            authApi.login(USERNAME_INPUT, PASSWORD_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        val result = accessTokenRepository.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+        assertTrue(result is AccessTokenResult.Success)
+    }
+
+    @Test
+    fun `login failure with InvalidCredentials, returns AccessTokenResult#InvalidCredentials`() =
+        runBlocking {
+            coEvery {
+                authApi.login(USERNAME_INPUT, PASSWORD_INPUT)
+            } returns AuthResult.InvalidCredentials
+
+            val actual = accessTokenRepository.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+            assertEquals(AccessTokenResult.InvalidCredentials, actual)
+        }
+
+    @Test
+    fun `login failure with other error, returns AccessTokenResult#CommunicationError`() =
+        runBlocking {
+            coEvery {
+                authApi.login(USERNAME_INPUT, PASSWORD_INPUT)
+            } returns AuthResult.BadRequest
+
+            val actual = accessTokenRepository.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+            assertEquals(AccessTokenResult.CommunicationError, actual)
+        }
+
+    @Test
+    fun `refresh on success, stores the accessToken`() = runBlocking {
+        coEvery {
+            authApi.refresh(REFRESH_TOKEN_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        accessTokenRepository.refresh()
+
+        verify { authProvider.accessToken = ACCESS_TOKEN }
+    }
+
+    @Test
+    fun `refresh on success, stores the refreshToken`() = runBlocking {
+        coEvery {
+            authApi.refresh(REFRESH_TOKEN_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        accessTokenRepository.refresh()
+
+        verify { authProvider.refreshToken = REFRESH_TOKEN }
+    }
+
+    @Test
+    fun `refresh on success, returns AccessTokenResult#Success`() = runBlocking {
+        coEvery {
+            authApi.refresh(REFRESH_TOKEN_INPUT)
+        } returns AuthResult.Success(ACCESS_TOKEN, REFRESH_TOKEN)
+
+        val result = accessTokenRepository.refresh()
+
+        assertTrue(result is AccessTokenResult.Success)
+    }
+
+    @Test
+    fun `refresh failure with InvalidCredentials, returns AccessTokenResult#InvalidCredentials`() =
+        runBlocking {
+            coEvery {
+                authApi.refresh(REFRESH_TOKEN_INPUT)
+            } returns AuthResult.InvalidCredentials
+
+            val actual = accessTokenRepository.refresh()
+
+            assertEquals(AccessTokenResult.InvalidCredentials, actual)
+        }
+
+    @Test
+    fun `refresh failure with other error, returns AccessTokenResult#CommunicationError`() =
+        runBlocking {
+            coEvery {
+                authApi.refresh(REFRESH_TOKEN_INPUT)
+            } returns AuthResult.BadRequest
+
+            val actual = accessTokenRepository.refresh()
+
+            assertEquals(AccessTokenResult.CommunicationError, actual)
+        }
+
+    @Test
+    fun `clear notifies provider to clear tokens`() {
+        every { authProvider.clearAuth() } just runs
+
+        accessTokenRepository.clear()
+
+        verify { authProvider.clearAuth() }
+    }
+}

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/AuthProviderTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/AuthProviderTests.kt
@@ -1,4 +1,4 @@
-package com.chesire.nekome.kitsu
+package com.chesire.nekome.datasource.auth.local
 
 import android.content.SharedPreferences
 import com.chesire.nekome.encryption.Cryption
@@ -15,6 +15,7 @@ private const val KITSU_ACCESS_TOKEN_KEY = "KEY_KITSU_ACCESS_TOKEN"
 private const val KITSU_REFRESH_TOKEN_KEY = "KEY_KITSU_REFRESH_TOKEN"
 
 class AuthProviderTests {
+
     @Test
     fun `accessToken#get returns the decrypted token`() {
         val expected = "accessToken"

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptorTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptorTests.kt
@@ -1,6 +1,6 @@
-package com.chesire.nekome.kitsu.interceptors
+package com.chesire.nekome.datasource.auth.remote
 
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AuthInjectionInterceptorTests {
+
     @Test
     fun `authorization header gets added correctly`() {
         val token = "AccessTokenPass"

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptorTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthInjectionInterceptorTests.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.datasource.auth.remote
 
-import com.chesire.nekome.datasource.auth.local.AuthProvider
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -14,7 +14,7 @@ class AuthInjectionInterceptorTests {
     fun `authorization header gets added correctly`() {
         val token = "AccessTokenPass"
         val expected = "Bearer $token"
-        val mockProvider = mockk<AuthProvider> {
+        val mockRepo = mockk<AccessTokenRepository> {
             every { accessToken } returns token
         }
         val headerCapture = slot<String>()
@@ -26,7 +26,7 @@ class AuthInjectionInterceptorTests {
             }
             every { proceed(any()) } returns mockk()
         }
-        val testObject = AuthInjectionInterceptor(mockProvider)
+        val testObject = AuthInjectionInterceptor(mockRepo)
 
         testObject.intercept(mockChain)
 

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptorTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptorTests.kt
@@ -1,7 +1,8 @@
 package com.chesire.nekome.datasource.auth.remote
 
 import com.chesire.nekome.core.AuthCaster
-import com.chesire.nekome.core.Resource
+import com.chesire.nekome.datasource.auth.AccessTokenRepository
+import com.chesire.nekome.datasource.auth.AccessTokenResult
 import com.chesire.nekome.datasource.auth.AuthException
 import com.chesire.nekome.datasource.auth.local.AuthProvider
 import io.mockk.Runs
@@ -24,8 +25,7 @@ class AuthRefreshInterceptorTests {
 
     @Test
     fun `successful response just returns response`() = runBlocking {
-        val mockProvider = mockk<AuthProvider>()
-        val mockAuth = mockk<AuthApi>()
+        val mockRepo = mockk<AccessTokenRepository>()
         val mockAuthCaster = mockk<AuthCaster>()
         val response = mockk<Response> {
             every { isSuccessful } returns true
@@ -34,18 +34,17 @@ class AuthRefreshInterceptorTests {
             every { request() } returns mockk()
             every { proceed(any()) } returns response
         }
-        val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
+        val testObject = AuthRefreshInterceptor(mockRepo, mockAuthCaster)
 
         val result = testObject.intercept(mockChain)
 
-        coVerify(exactly = 0) { mockAuth.refresh() }
+        coVerify(exactly = 0) { mockRepo.refresh() }
         assertTrue(result.isSuccessful)
     }
 
     @Test
     fun `failure response with code !403 just returns response`() = runBlocking {
-        val mockProvider = mockk<AuthProvider>()
-        val mockAuth = mockk<AuthApi>()
+        val mockRepo = mockk<AccessTokenRepository>()
         val mockAuthCaster = mockk<AuthCaster>()
         val response = mockk<Response> {
             every { isSuccessful } returns false
@@ -55,23 +54,18 @@ class AuthRefreshInterceptorTests {
             every { request() } returns mockk()
             every { proceed(any()) } returns response
         }
-        val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
+        val testObject = AuthRefreshInterceptor(mockRepo, mockAuthCaster)
 
         val result = testObject.intercept(mockChain)
 
-        coVerify(exactly = 0) { mockAuth.refresh() }
+        coVerify(exactly = 0) { mockRepo.refresh() }
         assertEquals(response, result)
     }
 
     @Test
     fun `getting new auth failure, notifies authCaster issue refreshing`() = runBlocking {
-        val mockProvider = mockk<AuthProvider>()
-        val mockAuth = mockk<AuthApi> {
-            coEvery {
-                refresh()
-            } coAnswers {
-                Resource.Error("Failure")
-            }
+        val mockRepo = mockk<AccessTokenRepository> {
+            coEvery { refresh() } returns AccessTokenResult.CommunicationError
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -87,7 +81,7 @@ class AuthRefreshInterceptorTests {
             every { request() } returns mockk()
             every { proceed(any()) } returns response
         }
-        val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
+        val testObject = AuthRefreshInterceptor(mockRepo, mockAuthCaster)
 
         try {
             testObject.intercept(mockChain)
@@ -95,19 +89,15 @@ class AuthRefreshInterceptorTests {
             // Ignore the crash
         }
 
-        coVerify(exactly = 1) { mockAuth.refresh() }
+        coVerify(exactly = 1) { mockRepo.refresh() }
         verify { mockAuthCaster.issueRefreshingToken() }
     }
 
     @Test(expected = AuthException::class)
     fun `getting new auth failure, throws AuthException`() = runBlocking {
         val mockProvider = mockk<AuthProvider>()
-        val mockAuth = mockk<AuthApi> {
-            coEvery {
-                refresh()
-            } coAnswers {
-                Resource.Error("Failure")
-            }
+        val mockRepo = mockk<AccessTokenRepository> {
+            coEvery { refresh() } returns AccessTokenResult.CommunicationError
         }
         val mockAuthCaster = mockk<AuthCaster> {
             every { issueRefreshingToken() } just Runs
@@ -123,7 +113,7 @@ class AuthRefreshInterceptorTests {
             every { request() } returns mockk()
             every { proceed(any()) } returns response
         }
-        val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
+        val testObject = AuthRefreshInterceptor(mockRepo, mockAuthCaster)
 
         testObject.intercept(mockChain)
 
@@ -132,15 +122,9 @@ class AuthRefreshInterceptorTests {
 
     @Test
     fun `getting new auth retries previous request`() = runBlocking {
-        val mockProvider = mockk<AuthProvider> {
+        val mockRepo = mockk<AccessTokenRepository> {
             every { accessToken } returns "accessToken"
-        }
-        val mockAuth = mockk<AuthApi> {
-            coEvery {
-                refresh()
-            } coAnswers {
-                Resource.Success(mockk())
-            }
+            coEvery { refresh() } returns AccessTokenResult.Success
         }
         val mockAuthCaster = mockk<AuthCaster>()
         val response = mockk<Response> {
@@ -154,7 +138,7 @@ class AuthRefreshInterceptorTests {
             every { request() } returns mockk(relaxed = true)
             every { proceed(any()) } returns response
         }
-        val testObject = AuthRefreshInterceptor(mockProvider, mockAuth, mockAuthCaster)
+        val testObject = AuthRefreshInterceptor(mockRepo, mockAuthCaster)
 
         testObject.intercept(mockChain)
 

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptorTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/remote/AuthRefreshInterceptorTests.kt
@@ -1,10 +1,9 @@
-package com.chesire.nekome.kitsu.interceptors
+package com.chesire.nekome.datasource.auth.remote
 
 import com.chesire.nekome.core.AuthCaster
 import com.chesire.nekome.core.Resource
-import com.chesire.nekome.datasource.auth.remote.AuthApi
-import com.chesire.nekome.kitsu.AuthException
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.AuthException
+import com.chesire.nekome.datasource.auth.local.AuthProvider
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -32,7 +32,6 @@ android {
 dependencies {
     implementation project(":libraries:core")
     implementation project(':libraries:datasource:auth')
-    implementation project(":libraries:encryption")
     implementation project(':libraries:kitsu')
 
     implementation "androidx.core:core-ktx:$corektx_version"

--- a/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
+++ b/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
@@ -1,35 +1,30 @@
 package com.chesire.nekome.kitsu.auth
 
-import com.chesire.nekome.core.Resource
-import com.chesire.nekome.kitsu.AuthProvider
+import com.chesire.nekome.datasource.auth.AuthException
+import com.chesire.nekome.datasource.auth.remote.AuthResult
 import com.chesire.nekome.kitsu.auth.dto.AuthResponseDto
 import com.chesire.nekome.kitsu.auth.dto.LoginRequestDto
 import com.chesire.nekome.kitsu.auth.dto.RefreshTokenRequestDto
-import io.mockk.CapturingSlot
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import okhttp3.ResponseBody
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
 import java.net.UnknownHostException
 
+private const val USERNAME_INPUT = "username"
+private const val PASSWORD_INPUT = "password"
+private const val REFRESH_TOKEN_INPUT = "refreshToken"
+
 class KitsuAuthTests {
 
     @Test
-    fun `login failure response returns Resource#Error with errorBody`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val expected = "errorBodyString"
-        val mockProvider = mockk<AuthProvider>()
+    fun `login failure response returns AuthResult#BadRequest`() = runBlocking {
         val mockResponseBody = mockk<ResponseBody> {
-            every { string() } returns expected
+            every { string() } returns "errorBodyString"
         }
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns false
@@ -38,201 +33,105 @@ class KitsuAuthTests {
         }
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
+                loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+            } returns mockResponse
         }
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
+        val classUnderTest = KitsuAuth(mockService)
 
-        val actual = classUnderTest.login(usernameInput, passwordInput)
+        val actual = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
 
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
-        }
+        assertEquals(AuthResult.BadRequest, actual)
     }
 
     @Test
-    fun `login failure response returns Resource#Error with message if no error`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val expected = "responseBodyString"
-
-        val mockProvider = mockk<AuthProvider>()
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns false
-            every { errorBody() } returns null
-            every { message() } returns expected
-            every { code() } returns 0
-        }
-        val mockService = mockk<KitsuAuthService> {
-            coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
-        }
-
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.login(usernameInput, passwordInput)
-
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
-        }
-    }
-
-    @Test
-    fun `login successful response with no body returns Resource#Error`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val expected = "Response body is null"
-
-        val mockProvider = mockk<AuthProvider>()
+    fun `login successful response with no body returns AuthResult#BadRequest`() = runBlocking {
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns true
             every { body() } returns null
-            every { message() } returns expected
+            every { message() } returns "Response body is null"
         }
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
+                loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+            } returns mockResponse
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.login(usernameInput, passwordInput)
+        val actual = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
 
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
-        }
+        assertEquals(AuthResult.BadRequest, actual)
     }
 
     @Test
-    fun `login successful response with body returns Resource#Success`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val loginResponse = AuthResponseDto("accessToken", "refreshToken")
-
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = any() } just Runs
-            every { refreshToken = any() } just Runs
-        }
+    fun `login successful response with body returns AuthResult#Success`() = runBlocking {
+        val expectedAccessToken = "accessToken"
+        val expectedRefreshToken = "refreshToken"
+        val loginResponse = AuthResponseDto(expectedAccessToken, expectedRefreshToken)
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns true
             every { body() } returns loginResponse
         }
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
+                loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+            } returns mockResponse
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.login(usernameInput, passwordInput)
+        val actual = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
 
-        when (actual) {
-            is Resource.Success -> assertTrue(true)
-            is Resource.Error -> error("Test has failed")
-        }
+        check(actual is AuthResult.Success)
+        assertEquals(expectedAccessToken, actual.accessToken)
+        assertEquals(expectedRefreshToken, actual.refreshToken)
     }
 
     @Test
-    fun `login successful response with body saves an access token`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val expected = "expectedAccessToken"
-        val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto(expected, "refreshToken")
+    fun `login on thrown UnknownHostException return AuthResult#CouldNotReachServer`() =
+        runBlocking {
+            val mockService = mockk<KitsuAuthService> {
+                coEvery {
+                    loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+                } throws UnknownHostException()
+            }
+            val classUnderTest = KitsuAuth(mockService)
 
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = capture(slot) } just Runs
-            every { refreshToken = any() } just Runs
+            val result = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
+
+            assertEquals(AuthResult.CouldNotReachServer, result)
         }
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns true
-            every { body() } returns loginResponse
-        }
+
+    @Test
+    fun `login on thrown AuthException return AuthResult#CouldNotRefresh`() = runBlocking {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
+                loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+            } throws AuthException()
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        classUnderTest.login(usernameInput, passwordInput)
+        val result = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
 
-        assertEquals(expected, slot.captured)
+        assertEquals(AuthResult.CouldNotRefresh, result)
     }
 
     @Test
-    fun `login successful response with body saves a refresh token`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-        val expected = "expectedRefreshToken"
-        val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto("accessToken", expected)
-
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = any() } just Runs
-            every { refreshToken = capture(slot) } just Runs
-        }
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns true
-            every { body() } returns loginResponse
-        }
+    fun `login on thrown other Exception return AuthResult#BadRequest`() = runBlocking {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } coAnswers {
-                mockResponse
-            }
+                loginAsync(LoginRequestDto(USERNAME_INPUT, PASSWORD_INPUT))
+            } throws IllegalArgumentException()
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        classUnderTest.login(usernameInput, passwordInput)
+        val result = classUnderTest.login(USERNAME_INPUT, PASSWORD_INPUT)
 
-        assertEquals(expected, slot.captured)
+        assertEquals(AuthResult.BadRequest, result)
     }
 
     @Test
-    fun `login on thrown exception return Resource#Error`() = runBlocking {
-        val usernameInput = "username"
-        val passwordInput = "password"
-
-        val mockService = mockk<KitsuAuthService> {
-            coEvery {
-                loginAsync(LoginRequestDto(usernameInput, passwordInput))
-            } throws UnknownHostException()
-        }
-        val mockProvider = mockk<AuthProvider>()
-
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val result = classUnderTest.login(usernameInput, passwordInput)
-
-        when (result) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertTrue(true)
-        }
-    }
-
-    @Test
-    fun `refresh failure response returns Resource#Error with errorBody`() = runBlocking {
-        val expected = "errorBodyString"
-
-        val mockProvider = mockk<AuthProvider> {
-            every { refreshToken } returns "token"
-        }
+    fun `refresh failure response returns AuthResult#BadRequest`() = runBlocking {
         val mockResponseBody = mockk<ResponseBody> {
-            every { string() } returns expected
+            every { string() } returns "errorBodyString"
         }
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns false
@@ -242,200 +141,118 @@ class KitsuAuthTests {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
                 refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
-            }
+            } returns mockResponse
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.refresh()
+        val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
-        }
+        assertEquals(AuthResult.BadRequest, actual)
     }
 
     @Test
-    fun `refresh failure response returns Resource#Error with message if no error`() = runBlocking {
-        val expected = "responseBodyString"
-
-        val mockProvider = mockk<AuthProvider> {
-            every { refreshToken } returns "token"
-        }
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns false
-            every { errorBody() } returns null
-            every { message() } returns expected
-            every { code() } returns 0
-        }
-        val mockService = mockk<KitsuAuthService> {
-            coEvery {
-                refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
+    fun `refresh failure response returns AuthResult#BadRequest with message if no error`() =
+        runBlocking {
+            val mockResponse = mockk<Response<AuthResponseDto>> {
+                every { isSuccessful } returns false
+                every { errorBody() } returns null
+                every { message() } returns "responseBodyString"
+                every { code() } returns 0
             }
-        }
+            val mockService = mockk<KitsuAuthService> {
+                coEvery {
+                    refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
+                } returns mockResponse
+            }
+            val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.refresh()
+            val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
+            assertEquals(AuthResult.BadRequest, actual)
         }
-    }
 
     @Test
-    fun `refresh successful response with no body returns Resource#Error`() = runBlocking {
-        val expected = "Response body is null"
-
-        val mockProvider = mockk<AuthProvider> {
-            every { refreshToken } returns "token"
-        }
+    fun `refresh successful response with no body returns AuthResult#BadRequest`() = runBlocking {
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns true
             every { body() } returns null
-            every { message() } returns expected
+            every { message() } returns "Response body is null"
         }
         val mockService = mockk<KitsuAuthService> {
             coEvery {
                 refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
-            }
+            } returns mockResponse
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.refresh()
+        val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        when (actual) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertEquals(expected, actual.msg)
-        }
+        assertEquals(AuthResult.BadRequest, actual)
     }
 
     @Test
-    fun `refresh successful response with body returns Resource#Success`() = runBlocking {
-        val loginResponse =
-            AuthResponseDto("accessToken", "refreshToken")
-
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = any() } just Runs
-            every { refreshToken } returns "token"
-            every { refreshToken = any() } just Runs
-        }
+    fun `refresh successful response with body returns AuthResult#Success`() = runBlocking {
+        val expectedAccessToken = "accessToken"
+        val expectedRefreshToken = "refreshToken"
+        val loginResponse = AuthResponseDto(expectedAccessToken, expectedRefreshToken)
         val mockResponse = mockk<Response<AuthResponseDto>> {
             every { isSuccessful } returns true
             every { body() } returns loginResponse
         }
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
-            }
+                refreshAccessTokenAsync(RefreshTokenRequestDto(REFRESH_TOKEN_INPUT))
+            } returns mockResponse
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val actual = classUnderTest.refresh()
+        val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        when (actual) {
-            is Resource.Success -> assertTrue(true)
-            is Resource.Error -> error("Test has failed")
-        }
+        check(actual is AuthResult.Success)
+        assertEquals(expectedAccessToken, actual.accessToken)
+        assertEquals(expectedRefreshToken, actual.refreshToken)
     }
 
     @Test
-    fun `refresh successful response with body saves an access token`() = runBlocking {
-        val expected = "expectedAccessToken"
-        val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto(expected, "refreshToken")
+    fun `refresh on thrown UnknownHostException return AuthResult#CouldNotReachServer`() =
+        runBlocking {
+            val mockService = mockk<KitsuAuthService> {
+                coEvery {
+                    refreshAccessTokenAsync(RefreshTokenRequestDto(REFRESH_TOKEN_INPUT))
+                } throws UnknownHostException()
+            }
+            val classUnderTest = KitsuAuth(mockService)
 
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = capture(slot) } just Runs
-            every { refreshToken } returns "token"
-            every { refreshToken = any() } just Runs
+            val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
+
+            assertEquals(AuthResult.CouldNotReachServer, actual)
         }
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns true
-            every { body() } returns loginResponse
-        }
+
+    @Test
+    fun `refresh on thrown AuthException return AuthResult#CouldNotRefresh`() = runBlocking {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
-            }
+                refreshAccessTokenAsync(RefreshTokenRequestDto(REFRESH_TOKEN_INPUT))
+            } throws AuthException()
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        classUnderTest.refresh()
+        val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        assertEquals(expected, slot.captured)
+        assertEquals(AuthResult.CouldNotRefresh, actual)
     }
 
     @Test
-    fun `refresh successful response with body saves a refresh token`() = runBlocking {
-        val expected = "expectedRefreshToken"
-        val slot = CapturingSlot<String>()
-        val loginResponse = AuthResponseDto("accessToken", expected)
-
-        val mockProvider = mockk<AuthProvider> {
-            every { accessToken = any() } just Runs
-            every { refreshToken } returns "token"
-            every { refreshToken = capture(slot) } just Runs
-        }
-        val mockResponse = mockk<Response<AuthResponseDto>> {
-            every { isSuccessful } returns true
-            every { body() } returns loginResponse
-        }
+    fun `refresh on thrown other exception return AuthResult#BadRequest`() = runBlocking {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
-                refreshAccessTokenAsync(RefreshTokenRequestDto("token"))
-            } coAnswers {
-                mockResponse
-            }
+                refreshAccessTokenAsync(RefreshTokenRequestDto(REFRESH_TOKEN_INPUT))
+            } throws java.lang.IllegalArgumentException()
         }
+        val classUnderTest = KitsuAuth(mockService)
 
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        classUnderTest.refresh()
+        val actual = classUnderTest.refresh(REFRESH_TOKEN_INPUT)
 
-        assertEquals(expected, slot.captured)
-    }
-
-    @Test
-    fun `refresh on thrown exception return Resource#Error`() = runBlocking {
-        val tokenInput = "token"
-
-        val mockService = mockk<KitsuAuthService> {
-            coEvery {
-                refreshAccessTokenAsync(RefreshTokenRequestDto(tokenInput))
-            } throws UnknownHostException()
-        }
-        val mockProvider = mockk<AuthProvider> {
-            every { refreshToken } returns tokenInput
-        }
-
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        val result = classUnderTest.refresh()
-
-        when (result) {
-            is Resource.Success -> error("Test has failed")
-            is Resource.Error -> assertTrue(true)
-        }
-    }
-
-    @Test
-    fun `clearAuth clears auth in the provider`() = runBlocking {
-        val mockService = mockk<KitsuAuthService>()
-        val mockProvider = mockk<AuthProvider> {
-            every { clearAuth() } just Runs
-        }
-
-        val classUnderTest = KitsuAuth(mockService, mockProvider)
-        classUnderTest.clearAuth()
-
-        verify { mockProvider.clearAuth() }
+        assertEquals(AuthResult.BadRequest, actual)
     }
 }

--- a/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
+++ b/libraries/kitsu/auth/src/test/java/com/chesire/nekome/kitsu/auth/KitsuAuthTests.kt
@@ -247,7 +247,7 @@ class KitsuAuthTests {
         val mockService = mockk<KitsuAuthService> {
             coEvery {
                 refreshAccessTokenAsync(RefreshTokenRequestDto(REFRESH_TOKEN_INPUT))
-            } throws java.lang.IllegalArgumentException()
+            } throws IllegalArgumentException()
         }
         val classUnderTest = KitsuAuth(mockService)
 

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -32,7 +32,6 @@ android {
 dependencies {
     implementation project(":libraries:core")
     implementation project(":libraries:datasource:auth")
-    implementation project(":libraries:encryption")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$corektx_version"

--- a/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
+++ b/libraries/kitsu/src/main/java/com/chesire/nekome/kitsu/ResponseParsing.kt
@@ -1,6 +1,7 @@
 package com.chesire.nekome.kitsu
 
 import com.chesire.nekome.core.Resource
+import com.chesire.nekome.datasource.auth.AuthException
 import retrofit2.Response
 import java.net.UnknownHostException
 

--- a/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/ResponseParsingTests.kt
+++ b/libraries/kitsu/src/test/java/com/chesire/nekome/kitsu/ResponseParsingTests.kt
@@ -11,6 +11,7 @@ import retrofit2.Response
 import java.net.UnknownHostException
 
 class ResponseParsingTests {
+
     @Test
     fun `Response#parse !isSuccessful false returns Resource#Error`() {
         val response = Response.error<Any>(


### PR DESCRIPTION
Move a bunch of the auth logic into a new data source module for it. 
This adds a new repository that everything should go through if it wants to access the login/refresh methods, and also keeps the api methods cleaner.