### PR TITLE
chore: remove the all-open plugin as it isnt required anymore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
-        classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Since allopen is no longer used, it can be removed from the project.