### PR TITLE
chore: cleanup dependency files a bit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,13 +78,13 @@ dependencies {
     implementation project(":libraries:kitsu:user")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.hilt:hilt-work:$hiltx_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$viewmodel_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"

--- a/build.gradle
+++ b/build.gradle
@@ -66,13 +66,13 @@ ext {
     // App
     appcompat_version = "1.3.0"
     coil_version = "1.3.0"
-    constraint_layout_version = "2.0.4"
-    corektx_version = "1.6.0-rc01"
+    constraintlayout_version = "2.0.4"
+    core_version = "1.6.0"
     coroutines_version = "1.5.1"
-    dagger_version = "2.29.1"
-    fragmentctx_version = "1.3.5"
+    fragment_version = "1.3.5"
     hiltx_version = "1.0.0"
     lifecycle_version = "2.2.0"
+    livedata_version = "2.2.0"
     lintrules_version = "1.2.6"
     liveevent_version = "1.3.0"
     material_version = "1.4.0"
@@ -82,6 +82,7 @@ ext {
     retrofit_version = "2.9.0"
     room_version = "2.3.0"
     timber_version = "4.7.1"
+    viewmodel_version = "2.2.0"
 
     // Tests
     coretesting_version = "2.1.0"

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -37,11 +37,11 @@ dependencies {
     implementation project(":libraries:datasource:trending")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$viewmodel_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     implementation project(":libraries:datasource:user")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
@@ -55,9 +55,6 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
-
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
 
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 }

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -35,12 +35,12 @@ dependencies {
     implementation project(":libraries:datasource:user")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$viewmodel_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.android.material:material:$material_version"

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -37,10 +37,10 @@ dependencies {
     implementation project(":libraries:datasource:series")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -35,12 +35,12 @@ dependencies {
     implementation project(":libraries:datasource:series")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$livedata_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$viewmodel_version"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:lifecycle:$materialdialog_version"

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.browser:browser:1.3.0"
-    implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragmentctx_version"
+    implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -33,7 +33,7 @@ android {
 dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.browser:browser:1.3.0"
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation project(":libraries:core")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "androidx.room:room-ktx:$room_version"
     api "androidx.room:room-runtime:$room_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"

--- a/libraries/datasource/auth/build.gradle
+++ b/libraries/datasource/auth/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation project(':libraries:core')
     implementation project(":libraries:encryption")
 
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation project(':libraries:datasource:auth')
     implementation project(':libraries:kitsu')
 
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation project(":libraries:datasource:auth")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation "androidx.core:core-ktx:$corektx_version"
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"


### PR DESCRIPTION
Remove some unused dependencies in some files, and cleanup the naming of the version params. Also
split up the lifecycle version so its split into livedata and viewmodel.