### PR TITLE
fix: crash in encryption library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ ext {
     preferences_version = "1.1.1"
     retrofit_version = "2.9.0"
     room_version = "2.3.0"
+    security_version = "1.0.0"
     timber_version = "5.0.1"
     viewmodel_version = "2.3.1"
 

--- a/libraries/core/src/main/java/com/chesire/nekome/core/extensions/SharedPreferenceExtensions.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/extensions/SharedPreferenceExtensions.kt
@@ -1,0 +1,28 @@
+package com.chesire.nekome.core.extensions
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+/**
+ * Migrates keys to a new [SharedPreferences] instance.
+ * Will only migrate keys that have a value of type [String].
+ */
+fun SharedPreferences.migrateTo(encryptedPreferences: SharedPreferences) {
+    // If the current list is empty, no need to migrate
+    if (all.isEmpty()) {
+        return
+    }
+
+    val migrated = mutableListOf<String>()
+    all.forEach { (key, value) ->
+        if (value is String) {
+            migrated.add(key)
+            encryptedPreferences.edit {
+                putString(key, value)
+            }
+        }
+    }
+    edit {
+        migrated.forEach(::remove)
+    }
+}

--- a/libraries/datasource/auth/build.gradle
+++ b/libraries/datasource/auth/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(":libraries:encryption")
 
     implementation "androidx.core:core-ktx:$core_version"
+    implementation "androidx.security:security-crypto:$security_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/libraries/datasource/auth/src/main/AndroidManifest.xml
+++ b/libraries/datasource/auth/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.datasource.auth" />
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    package="com.chesire.nekome.datasource.auth">
+
+    <uses-sdk tools:overrideLibrary="androidx.security" />
+</manifest>

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
@@ -16,18 +16,27 @@ class AuthProvider @Inject constructor(
         migrateFromV1ToV2()
     }
 
+    /**
+     * Retrieve or set the current access token.
+     */
     var accessToken: String
         get() = v2Auth.accessToken
         set(value) {
             v2Auth.accessToken = value
         }
 
+    /**
+     * Retrieve or set the refresh token used to get a new access token.
+     */
     var refreshToken: String
         get() = v2Auth.refreshToken
         set(value) {
             v2Auth.refreshToken = value
         }
 
+    /**
+     * Clears out the current auth credentials.
+     */
     fun clearAuth() {
         v1Auth.clear()
         v2Auth.clear()

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
@@ -1,10 +1,12 @@
 package com.chesire.nekome.datasource.auth.local
 
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Provides authorization for Kitsu access.
  */
+@Singleton // TODO: Keep as a singleton while we need to do the migration
 class AuthProvider @Inject constructor(
     private val v1Auth: LocalAuthV1,
     private val v2Auth: LocalAuthV2
@@ -26,7 +28,10 @@ class AuthProvider @Inject constructor(
             v2Auth.refreshToken = value
         }
 
-    fun clearAuth() = v2Auth.clear()
+    fun clearAuth() {
+        v1Auth.clear()
+        v2Auth.clear()
+    }
 
     private fun migrateFromV1ToV2() {
         if (!v1Auth.hasCredentials) {

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/AuthProvider.kt
@@ -1,58 +1,43 @@
 package com.chesire.nekome.datasource.auth.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
-import com.chesire.nekome.encryption.Cryption
 import javax.inject.Inject
-
-private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN"
-private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN"
-private const val ALIAS = "kitsuPrivateAuth"
 
 /**
  * Provides authorization for Kitsu access.
- *
- * Auth is encrypted using [cryption], it is then stored in the [preferences] for access.
  */
 class AuthProvider @Inject constructor(
-    private val preferences: SharedPreferences,
-    private val cryption: Cryption
+    private val v1Auth: LocalAuthV1,
+    private val v2Auth: LocalAuthV2
 ) {
-    /**
-     * Access token to put into the Kitsu requests.
-     */
-    var accessToken: String
-        get() = decryptedToken(preferences.getString(ACCESS_TOKEN, "") ?: "")
-        set(newAccessToken) {
-            preferences.edit {
-                putString(ACCESS_TOKEN, cryption.encrypt(newAccessToken, ALIAS))
-            }
-        }
 
-    /**
-     * Refresh token to request a new access token.
-     */
-    var refreshToken: String
-        get() = decryptedToken(preferences.getString(REFRESH_TOKEN, "") ?: "")
-        set(newRefreshToken) {
-            preferences.edit {
-                putString(REFRESH_TOKEN, cryption.encrypt(newRefreshToken, ALIAS))
-            }
-        }
-
-    private fun decryptedToken(preferenceValue: String): String {
-        return if (preferenceValue.isNotEmpty()) {
-            cryption.decrypt(preferenceValue, ALIAS)
-        } else {
-            ""
-        }
+    init {
+        migrateFromV1ToV2()
     }
 
-    /**
-     * Clears out any currently stored auth tokens.
-     */
-    fun clearAuth() = preferences.edit {
-        remove(ACCESS_TOKEN)
-        remove(REFRESH_TOKEN)
+    var accessToken: String
+        get() = v2Auth.accessToken
+        set(value) {
+            v2Auth.accessToken = value
+        }
+
+    var refreshToken: String
+        get() = v2Auth.refreshToken
+        set(value) {
+            v2Auth.refreshToken = value
+        }
+
+    fun clearAuth() = v2Auth.clear()
+
+    private fun migrateFromV1ToV2() {
+        if (!v1Auth.hasCredentials) {
+            return
+        }
+
+        val v1AccessToken = v1Auth.accessToken
+        val v1RefreshToken = v1Auth.refreshToken
+
+        v2Auth.accessToken = v1AccessToken
+        v2Auth.refreshToken = v1RefreshToken
+        v1Auth.clear()
     }
 }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuth.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuth.kt
@@ -1,0 +1,24 @@
+package com.chesire.nekome.datasource.auth.local
+
+internal interface LocalAuth {
+
+    /**
+     * Checks if there are credentials for this local auth.
+     */
+    val hasCredentials: Boolean
+
+    /**
+     * Access token to put into the api requests.
+     */
+    var accessToken: String
+
+    /**
+     * Refresh token to request a new access token.
+     */
+    var refreshToken: String
+
+    /**
+     * Clears out any currently stored auth tokens for this local auth.
+     */
+    fun clear()
+}

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuth.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuth.kt
@@ -1,5 +1,8 @@
 package com.chesire.nekome.datasource.auth.local
 
+/**
+ * Declares what a local auth instance must provide.
+ */
 internal interface LocalAuth {
 
     /**

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV1.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV1.kt
@@ -1,0 +1,67 @@
+package com.chesire.nekome.datasource.auth.local
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.chesire.nekome.encryption.Cryption
+import javax.inject.Inject
+
+private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN"
+private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN"
+private const val ALIAS = "kitsuPrivateAuth"
+
+@Deprecated("This is legacy and will be removed in a later release once migration has completed")
+class LocalAuthV1 @Inject constructor(
+    private val preferences: SharedPreferences,
+    private val cryption: Cryption
+) : LocalAuth {
+
+    override val hasCredentials: Boolean
+        get() = preferences.contains(ACCESS_TOKEN) || preferences.contains(REFRESH_TOKEN)
+
+    override var accessToken: String
+        get() {
+            val token = preferences.getString(ACCESS_TOKEN, null)
+            return if (token == null) {
+                ""
+            } else {
+                decryptToken(token)
+            }
+        }
+        set(newAccessToken) {
+            preferences.edit {
+                putString(ACCESS_TOKEN, cryption.encrypt(newAccessToken, ALIAS))
+            }
+        }
+
+    override var refreshToken: String
+        get() {
+            val token = preferences.getString(REFRESH_TOKEN, null)
+            return if (token == null) {
+                ""
+            } else {
+                decryptToken(token)
+            }
+        }
+        set(newRefreshToken) {
+            preferences.edit {
+                putString(REFRESH_TOKEN, cryption.encrypt(newRefreshToken, ALIAS))
+            }
+        }
+
+    override fun clear() = preferences.edit {
+        remove(ACCESS_TOKEN)
+        remove(REFRESH_TOKEN)
+    }
+
+    private fun decryptToken(preferenceValue: String): String {
+        return try {
+            if (preferenceValue.isNotEmpty()) {
+                cryption.decrypt(preferenceValue, ALIAS)
+            } else {
+                ""
+            }
+        } catch (ex: Exception) {
+            ""
+        }
+    }
+}

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV1.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV1.kt
@@ -9,6 +9,13 @@ private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN"
 private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN"
 private const val ALIAS = "kitsuPrivateAuth"
 
+/**
+ * Old version of how auth credentials were stored, uses an old encryption library which is liable
+ * to failure.
+ * Do not use this, instead use the latest [LocalAuthV2].
+ * Remove this class once migration for the majority of users has been performed.
+ */
+@Suppress("TooGenericExceptionCaught")
 @Deprecated("This is legacy and will be removed in a later release once migration has completed")
 class LocalAuthV1 @Inject constructor(
     private val preferences: SharedPreferences,

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
@@ -1,0 +1,37 @@
+package com.chesire.nekome.datasource.auth.local
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import javax.inject.Inject
+
+private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN_V2"
+private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN_v2"
+
+class LocalAuthV2 @Inject constructor(
+    private val preferences: SharedPreferences
+) : LocalAuth {
+
+    override val hasCredentials: Boolean
+        get() = preferences.contains(ACCESS_TOKEN) || preferences.contains(REFRESH_TOKEN)
+
+    override var accessToken: String
+        get() = preferences.getString(ACCESS_TOKEN, "") ?: ""
+        set(newAccessToken) {
+            preferences.edit {
+                putString(ACCESS_TOKEN, newAccessToken)
+            }
+        }
+
+    override var refreshToken: String
+        get() = preferences.getString(REFRESH_TOKEN, "") ?: ""
+        set(newRefreshToken) {
+            preferences.edit {
+                putString(ACCESS_TOKEN, newRefreshToken)
+            }
+        }
+
+    override fun clear() = preferences.edit {
+        remove(ACCESS_TOKEN)
+        remove(REFRESH_TOKEN)
+    }
+}

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
@@ -15,6 +15,9 @@ private const val UNENCRYPTED_NEKOME_AUTH_PREF = "UneNekomePrefStore"
 private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN_V2"
 private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN_v2"
 
+/**
+ * Stores auth credentials in the encrypted shares preferences.
+ */
 @Reusable
 class LocalAuthV2 @Inject constructor(
     @ApplicationContext private val context: Context
@@ -24,13 +27,13 @@ class LocalAuthV2 @Inject constructor(
 
     init {
         preferences = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            initializeEncryptedPreferences().also { encryptedPref ->
+            initEncryptedPreferences().also { encryptedPref ->
                 if (encryptedPref.all.isEmpty()) {
-                    initializeUnencryptedPreferences().migrateToEncrypted(encryptedPref)
+                    initUnencryptedPreferences().migrateToEncrypted(encryptedPref)
                 }
             }
         } else {
-            initializeUnencryptedPreferences()
+            initUnencryptedPreferences()
         }
     }
 
@@ -75,7 +78,7 @@ class LocalAuthV2 @Inject constructor(
         remove(REFRESH_TOKEN)
     }
 
-    private fun initializeEncryptedPreferences(): SharedPreferences {
+    private fun initEncryptedPreferences(): SharedPreferences {
         val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
         return EncryptedSharedPreferences.create(
             ENCRYPTED_NEKOME_AUTH_PREF,
@@ -86,7 +89,6 @@ class LocalAuthV2 @Inject constructor(
         )
     }
 
-    private fun initializeUnencryptedPreferences(): SharedPreferences {
-        return context.getSharedPreferences(UNENCRYPTED_NEKOME_AUTH_PREF, Context.MODE_PRIVATE)
-    }
+    private fun initUnencryptedPreferences(): SharedPreferences =
+        context.getSharedPreferences(UNENCRYPTED_NEKOME_AUTH_PREF, Context.MODE_PRIVATE)
 }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
@@ -1,15 +1,54 @@
 package com.chesire.nekome.datasource.auth.local
 
+import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
+private const val ENCRYPTED_NEKOME_AUTH_PREF = "ENekomePrefStore"
+private const val UNENCRYPTED_NEKOME_AUTH_PREF = "UneNekomePrefStore"
 private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN_V2"
 private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN_v2"
 
+@Reusable
 class LocalAuthV2 @Inject constructor(
-    private val preferences: SharedPreferences
+    @ApplicationContext private val context: Context
 ) : LocalAuth {
+
+    private val preferences: SharedPreferences
+
+    init {
+        val unencryptedPreferences = initializeUnencryptedPreferences()
+        preferences = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            initializeEncryptedPreferences().also {
+                unencryptedPreferences.migrateToEncrypted(it)
+            }
+        } else {
+            unencryptedPreferences
+        }
+    }
+
+    private fun SharedPreferences.migrateToEncrypted(encryptedPreferences: SharedPreferences) {
+        if (all.isEmpty()) {
+            return
+        }
+        all.forEach { (key, value) ->
+            if (value is String) {
+                encryptedPreferences.edit {
+                    putString(key, value)
+                }
+            }
+        }
+        edit {
+            remove(ACCESS_TOKEN)
+            remove(REFRESH_TOKEN)
+        }
+    }
 
     override val hasCredentials: Boolean
         get() = preferences.contains(ACCESS_TOKEN) || preferences.contains(REFRESH_TOKEN)
@@ -26,12 +65,27 @@ class LocalAuthV2 @Inject constructor(
         get() = preferences.getString(REFRESH_TOKEN, "") ?: ""
         set(newRefreshToken) {
             preferences.edit {
-                putString(ACCESS_TOKEN, newRefreshToken)
+                putString(REFRESH_TOKEN, newRefreshToken)
             }
         }
 
     override fun clear() = preferences.edit {
         remove(ACCESS_TOKEN)
         remove(REFRESH_TOKEN)
+    }
+
+    private fun initializeEncryptedPreferences(): SharedPreferences {
+        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        return EncryptedSharedPreferences.create(
+            ENCRYPTED_NEKOME_AUTH_PREF,
+            masterKeyAlias,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun initializeUnencryptedPreferences(): SharedPreferences {
+        return context.getSharedPreferences(UNENCRYPTED_NEKOME_AUTH_PREF, Context.MODE_PRIVATE)
     }
 }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2.kt
@@ -23,13 +23,14 @@ class LocalAuthV2 @Inject constructor(
     private val preferences: SharedPreferences
 
     init {
-        val unencryptedPreferences = initializeUnencryptedPreferences()
         preferences = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            initializeEncryptedPreferences().also {
-                unencryptedPreferences.migrateToEncrypted(it)
+            initializeEncryptedPreferences().also { encryptedPref ->
+                if (encryptedPref.all.isEmpty()) {
+                    initializeUnencryptedPreferences().migrateToEncrypted(encryptedPref)
+                }
             }
         } else {
-            unencryptedPreferences
+            initializeUnencryptedPreferences()
         }
     }
 

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
@@ -1,0 +1,51 @@
+package com.chesire.nekome.datasource.auth.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.chesire.nekome.core.extensions.migrateTo
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * Provider for [SharedPreferences] instances.
+ */
+class PreferenceProvider @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    /**
+     * Retrieves an instance of [SharedPreferences], providing an encrypted version if the SDK is
+     * high enough.
+     */
+    fun retrievePreferences(
+        encryptedStoreName: String,
+        unencryptedStoreName: String
+    ): SharedPreferences {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            initEncryptedPreferences(encryptedStoreName)
+                .also { encryptedPref ->
+                    if (encryptedPref.all.isEmpty()) {
+                        initUnencryptedPreferences(unencryptedStoreName).migrateTo(encryptedPref)
+                    }
+                }
+        } else {
+            initUnencryptedPreferences(unencryptedStoreName)
+        }
+    }
+
+    private fun initEncryptedPreferences(storeName: String) =
+        EncryptedSharedPreferences.create(
+            storeName,
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
+    private fun initUnencryptedPreferences(storeName: String): SharedPreferences =
+        context.getSharedPreferences(storeName, Context.MODE_PRIVATE)
+}

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
@@ -3,7 +3,6 @@ package com.chesire.nekome.datasource.auth.local
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
-import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.chesire.nekome.core.extensions.migrateTo

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/AuthProviderTests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/AuthProviderTests.kt
@@ -1,0 +1,131 @@
+package com.chesire.nekome.datasource.auth.local
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+private const val ACCESS_TOKEN = "access_token"
+private const val REFRESH_TOKEN = "refresh_token"
+
+class AuthProviderTests {
+
+    private lateinit var v1Auth: LocalAuthV1
+    private lateinit var v2Auth: LocalAuthV2
+
+    private lateinit var authProvider: AuthProvider
+
+    @Before
+    fun setup() {
+        v1Auth = mockk {
+            every { hasCredentials } returns false
+        }
+        v2Auth = mockk()
+        authProvider = AuthProvider(v1Auth, v2Auth)
+    }
+
+    @Test
+    fun `migration doesn't occur if no v1 credentials`() {
+        v1Auth = mockk {
+            every { hasCredentials } returns false
+        }
+        v2Auth = mockk()
+        authProvider = AuthProvider(v1Auth, v2Auth)
+
+        verify(exactly = 0) { v1Auth.accessToken }
+    }
+
+    @Test
+    fun `migration copies over access token to v2`() {
+        v1Auth = mockk {
+            every { hasCredentials } returns true
+            every { accessToken } returns ACCESS_TOKEN
+            every { refreshToken } returns REFRESH_TOKEN
+            every { clear() } just runs
+        }
+        v2Auth = mockk(relaxed = true)
+        authProvider = AuthProvider(v1Auth, v2Auth)
+
+        verify { v2Auth.accessToken = ACCESS_TOKEN }
+    }
+
+    @Test
+    fun `migration copies over refresh token to v2`() {
+        v1Auth = mockk {
+            every { hasCredentials } returns true
+            every { accessToken } returns ACCESS_TOKEN
+            every { refreshToken } returns REFRESH_TOKEN
+            every { clear() } just runs
+        }
+        v2Auth = mockk(relaxed = true)
+        authProvider = AuthProvider(v1Auth, v2Auth)
+
+        verify { v2Auth.refreshToken = REFRESH_TOKEN }
+    }
+
+    @Test
+    fun `migration clears v1 after migration`() {
+        v1Auth = mockk {
+            every { hasCredentials } returns true
+            every { accessToken } returns ACCESS_TOKEN
+            every { refreshToken } returns REFRESH_TOKEN
+            every { clear() } just runs
+        }
+        v2Auth = mockk(relaxed = true)
+        authProvider = AuthProvider(v1Auth, v2Auth)
+
+        verify { v1Auth.clear() }
+    }
+
+    @Test
+    fun `accessToken gets token from correct auth`() {
+        every { v2Auth.accessToken } returns ACCESS_TOKEN
+
+        authProvider.accessToken
+
+        verify { v2Auth.accessToken }
+    }
+
+    @Test
+    fun `accessToken sets token in correct auth`() {
+        every { v2Auth.accessToken = ACCESS_TOKEN } just runs
+
+        authProvider.accessToken = ACCESS_TOKEN
+
+        verify { v2Auth.accessToken = ACCESS_TOKEN }
+    }
+
+    @Test
+    fun `refreshToken gets token from correct auth`() {
+        every { v2Auth.refreshToken } returns REFRESH_TOKEN
+
+        authProvider.refreshToken
+
+        verify { v2Auth.refreshToken }
+    }
+
+    @Test
+    fun `refreshToken sets token in correct auth`() {
+        every { v2Auth.refreshToken = REFRESH_TOKEN } just runs
+
+        authProvider.refreshToken = REFRESH_TOKEN
+
+        verify { v2Auth.refreshToken = REFRESH_TOKEN }
+    }
+
+    @Test
+    fun `clearAuth clears out all auth instances`() {
+        every { v1Auth.clear() } just runs
+        every { v2Auth.clear() } just runs
+
+        authProvider.clearAuth()
+
+        verify {
+            v1Auth.clear()
+            v2Auth.clear()
+        }
+    }
+}

--- a/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2Tests.kt
+++ b/libraries/datasource/auth/src/test/java/com/chesire/nekome/datasource/auth/local/LocalAuthV2Tests.kt
@@ -1,0 +1,114 @@
+package com.chesire.nekome.datasource.auth.local
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private const val ACCESS_TOKEN = "KEY_KITSU_ACCESS_TOKEN_V2"
+private const val REFRESH_TOKEN = "KEY_KITSU_REFRESH_TOKEN_v2"
+
+class LocalAuthV2Tests {
+
+    private lateinit var sharedPreferencesEditor: SharedPreferences.Editor
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var preferenceProvider: PreferenceProvider
+    private lateinit var localAuthV2: LocalAuthV2
+
+    @Before
+    fun setup() {
+        sharedPreferencesEditor = mockk(relaxed = true)
+        sharedPreferences = mockk(relaxed = true) {
+            every { edit() } returns sharedPreferencesEditor
+        }
+        preferenceProvider = mockk {
+            every { retrievePreferences(any(), any()) } returns sharedPreferences
+        }
+        localAuthV2 = LocalAuthV2(preferenceProvider)
+    }
+
+    @Test
+    fun `hasCredentials returns true if access token exists`() {
+        every { sharedPreferences.contains(ACCESS_TOKEN) } returns true
+        every { sharedPreferences.contains(REFRESH_TOKEN) } returns false
+
+        assertTrue(localAuthV2.hasCredentials)
+    }
+
+    @Test
+    fun `hasCredentials returns true if refresh token exists`() {
+        every { sharedPreferences.contains(ACCESS_TOKEN) } returns false
+        every { sharedPreferences.contains(REFRESH_TOKEN) } returns true
+
+        assertTrue(localAuthV2.hasCredentials)
+    }
+
+    @Test
+    fun `hasCredentials returns true if both tokens exist`() {
+        every { sharedPreferences.contains(ACCESS_TOKEN) } returns true
+        every { sharedPreferences.contains(REFRESH_TOKEN) } returns true
+
+        assertTrue(localAuthV2.hasCredentials)
+    }
+
+    @Test
+    fun `hasCredentials returns false if neither tokens exist`() {
+        every { sharedPreferences.contains(ACCESS_TOKEN) } returns false
+        every { sharedPreferences.contains(REFRESH_TOKEN) } returns false
+
+        assertFalse(localAuthV2.hasCredentials)
+    }
+
+    @Test
+    fun `accessToken#get returns value from the shared preferences`() {
+        val expected = "0123456789"
+        every { sharedPreferences.getString(ACCESS_TOKEN, "") } returns expected
+
+        val actual = localAuthV2.accessToken
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `accessToken#set sets value into shared preferences`() {
+        val expected = "0123456789"
+
+        localAuthV2.accessToken = expected
+
+        verify { sharedPreferencesEditor.putString(ACCESS_TOKEN, expected) }
+    }
+
+    @Test
+    fun `refreshToken#get returns value from the shared preferences`() {
+        val expected = "0123456789"
+        every { sharedPreferences.getString(REFRESH_TOKEN, "") } returns expected
+
+        val actual = localAuthV2.refreshToken
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `refreshToken#set sets value into shared preferences`() {
+        val expected = "0123456789"
+
+        localAuthV2.refreshToken = expected
+
+        verify { sharedPreferencesEditor.putString(REFRESH_TOKEN, expected) }
+    }
+
+    @Test
+    fun `clear removes currently stored auth values`() {
+        localAuthV2.clear()
+
+        verify {
+            sharedPreferencesEditor.remove(ACCESS_TOKEN)
+            sharedPreferencesEditor.remove(REFRESH_TOKEN)
+        }
+    }
+}

--- a/libraries/encryption/src/main/java/com/chesire/nekome/encryption/KeystoreEncryption.kt
+++ b/libraries/encryption/src/main/java/com/chesire/nekome/encryption/KeystoreEncryption.kt
@@ -6,15 +6,15 @@ import com.thz.keystorehelper.KeyStoreManager
 /**
  * Used to encrypt and decrypt strings using the [KeyStoreManager].
  */
-class KeystoreEncryption(context: Context) : Cryption {
+class KeystoreEncryption(private val context: Context) : Cryption {
 
-    init {
+    override fun encrypt(text: String, alias: String): String {
         KeyStoreManager.init(context)
+        return KeyStoreManager.encryptData(text, alias)
     }
 
-    override fun encrypt(text: String, alias: String): String =
-        KeyStoreManager.encryptData(text, alias)
-
-    override fun decrypt(text: String, alias: String): String =
-        KeyStoreManager.decryptData(text, alias)
+    override fun decrypt(text: String, alias: String): String {
+        KeyStoreManager.init(context)
+        return KeyStoreManager.decryptData(text, alias)
+    }
 }


### PR DESCRIPTION
Crash is sometimes occurring when using the encryption library due to something wrong with the KeyStore in Android.
Done some debugging and it seemed to always be causing an issue while a value was in the preferences, so move away from using the library and instead use the new encrypted shared preferences when possible.

Once this has been merged for a few weeks the encryption library can be tore out completely.