### PR TITLE
fix: workmanager not being correctly initialized

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,9 +35,8 @@
             android:value="598.0dip" />
 
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            android:exported="false"
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
             tools:node="remove" />
 
         <activity


### PR DESCRIPTION
From version 2.6.0 of work manager the manifest needs to be changed or there are failures to run.
Previously the `tools:node="remove"` was being used as it was causing an issue with Hilt, this line
needed to be updated to the latest specified in
https://developer.android.com/jetpack/androidx/releases/work#2.6.0-alpha01.