### PR TITLE
refactor: use the AboutLibraries plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
+    id "com.mikepenz.aboutlibraries.plugin"
 }
 
 android {

--- a/app/src/main/java/com/chesire/nekome/injection/AppModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/AppModule.kt
@@ -16,6 +16,7 @@ import dagger.hilt.components.SingletonComponent
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
+
     /**
      * Provides the default [SharedPreferences] for the application.
      */

--- a/app/src/main/java/com/chesire/nekome/injection/FieldProvider.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/FieldProvider.kt
@@ -1,0 +1,23 @@
+package com.chesire.nekome.injection
+
+import com.chesire.nekome.R
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.FragmentComponent
+import java.lang.reflect.Field
+
+/**
+ * Dagger [Module] to provide the application [Field].
+ */
+@Module
+@InstallIn(FragmentComponent::class)
+object FieldProvider {
+
+    /**
+     * Provides the string fields.
+     * For use to show the open source libraries used.
+     */
+    @Provides
+    fun provideFields(): Array<Field> = R.string::class.java.fields
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 
 buildscript {
+    ext.aboutlibraries_version = "8.9.1"
     ext.hilt_version = "2.38.1"
     ext.jacoco_version = "0.8.7"
     ext.kotlin_version = "1.5.30"
@@ -13,6 +14,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
         classpath "com.android.tools.build:gradle:7.0.2"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
+        classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$aboutlibraries_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -25,8 +25,6 @@ android {
 }
 
 dependencies {
-    def aboutlibraries_version = "8.9.1"
-
     implementation project(":libraries:core")
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
@@ -41,12 +39,6 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "com.mikepenz:aboutlibraries:$aboutlibraries_version"
-    implementation "com.mikepenz:aboutlibraries-definitions:$aboutlibraries_version"
-
-    testImplementation "junit:junit:$junit_version"
-
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
 
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 }

--- a/features/settings/consumer-rules.pro
+++ b/features/settings/consumer-rules.pro
@@ -19,8 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
-# Needed for the AboutLibraries library to work
--keepclasseswithmembers class **.R$* {
-    public static final int define_*;
-}

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/oss/OssFragment.kt
@@ -8,25 +8,18 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import com.chesire.nekome.app.settings.R
 import com.mikepenz.aboutlibraries.LibsBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import java.lang.reflect.Field
+import javax.inject.Inject
 
 /**
  * Fragment that displays information about open source licenses that are used.
  */
+@AndroidEntryPoint
 class OssFragment : Fragment() {
-    // Commented out libraries are pulled in automatically, because the library already includes the
-    // xml file required, or it is supplied manually. We only need to specify the libraries that the
-    // about libraries plugin provides.
-    private val includedLibraries = arrayOf(
-        // "AboutLibraries",
-        // "coil",
-        "Dagger2",
-        // "lifecyklelog",
-        // "liveevent",
-        "materialdialogs",
-        "moshi",
-        "Retrofit",
-        "Timber"
-    )
+
+    @Inject
+    lateinit var fields: Array<Field>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,14 +31,11 @@ class OssFragment : Fragment() {
         }
     }
 
-    @Suppress("SpreadOperator")
     private fun createLicensePage() = LibsBuilder()
-        .withAutoDetect(false)
         .withLicenseShown(false)
         .withLicenseDialog(true)
         .withAboutIconShown(false)
         .withVersionShown(false)
-        .withFields(R.string::class.java.fields)
-        .withLibraries(*includedLibraries)
+        .withFields(fields)
         .supportFragment()
 }


### PR DESCRIPTION
Switch from using the Gradle dependency to get the definitions to instead use the plugin.

Closes #141 