### PR TITLE
chore: remove unused dependencies in gradle files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.preference:preference-ktx:$preferences_version"
+    implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.work:work-runtime-ktx:2.6.0"
     implementation "com.afollestad.material-dialogs:core:$materialdialog_version"
     implementation "com.afollestad.material-dialogs:input:$materialdialog_version"

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -50,8 +50,5 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
-
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 }

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -56,8 +56,5 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
-
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 }

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -35,8 +35,5 @@ dependencies {
 
     testImplementation "junit:junit:$junit_version"
 
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
-
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 }

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -41,8 +41,6 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "junit:junit:$junit_version"
 
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
-
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 }

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.core:core-ktx:$core_version"
     implementation "androidx.room:room-ktx:$room_version"
-    api "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-runtime:$room_version"
     implementation "com.chesire.lintrules:lint-gradle:$lintrules_version"
     implementation "com.chesire.lintrules:lint-xml:$lintrules_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"


### PR DESCRIPTION
Remove some unused dependencies and copy the Room runtime dependency into app so we don't need to 
use api