### PR TITLE
Add ability to sort by rating

### DIFF
--- a/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
@@ -132,6 +132,27 @@ class SortTests : UITest() {
             )
         }
     }
+
+    @Test
+    fun sortOptionEndDateSortsInRatingOrder() {
+        launchActivity()
+
+        seriesList {
+            sortSeries {
+                open()
+                selectByRating()
+            }
+        } validate {
+            isInOrder(
+                listOf(
+                    seriesData.series2.title,
+                    seriesData.series1.title,
+                    seriesData.series3.title,
+                    seriesData.series0.title
+                )
+            )
+        }
+    }
 }
 
 // Make an initial set of series items to compare sort with.
@@ -145,7 +166,8 @@ private data class InitialSortSeriesData(
         seriesType = SeriesType.Anime,
         userSeriesStatus = UserSeriesStatus.Current,
         startDate = "320/01/01",
-        endDate = "220/02/02"
+        endDate = "220/02/02",
+        rating = 10
     ),
     val series1: SeriesEntity = createSeriesEntity(
         id = 1,
@@ -154,7 +176,8 @@ private data class InitialSortSeriesData(
         seriesType = SeriesType.Anime,
         userSeriesStatus = UserSeriesStatus.Current,
         startDate = "021/01/01",
-        endDate = "121/02/02"
+        endDate = "121/02/02",
+        rating = 8
     ),
     val series2: SeriesEntity = createSeriesEntity(
         id = 2,
@@ -163,7 +186,8 @@ private data class InitialSortSeriesData(
         seriesType = SeriesType.Anime,
         userSeriesStatus = UserSeriesStatus.Current,
         startDate = "122/01/01",
-        endDate = "022/02/02"
+        endDate = "022/02/02",
+        rating = 7
     ),
     val series3: SeriesEntity = createSeriesEntity(
         id = 3,
@@ -172,7 +196,8 @@ private data class InitialSortSeriesData(
         seriesType = SeriesType.Anime,
         userSeriesStatus = UserSeriesStatus.Current,
         startDate = "223/01/01",
-        endDate = "323/02/02"
+        endDate = "323/02/02",
+        rating = 9
     )
 ) {
     /**

--- a/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
@@ -134,7 +134,7 @@ class SortTests : UITest() {
     }
 
     @Test
-    fun sortOptionEndDateSortsInRatingOrder() {
+    fun sortOptionRatingSortsInRatingOrder() {
         launchActivity()
 
         seriesList {

--- a/app/src/androidTest/java/com/chesire/nekome/robots/series/SortOptionRobot.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/robots/series/SortOptionRobot.kt
@@ -38,6 +38,11 @@ class SortOptionRobot {
     fun selectByEndDate() = clickOn(R.string.sort_by_end_date)
 
     /**
+     * Pick the "Rating" option, requires first calling [open].
+     */
+    fun selectByRating() = clickOn(R.string.sort_by_rating)
+
+    /**
      * Executes validation steps.
      * Requires opening the dialog, performing the check.
      */
@@ -68,5 +73,6 @@ class SortOptionResultsRobot {
         assertDisplayedAtPosition(R.id.md_recyclerview_content, 1, R.string.sort_by_title)
         assertDisplayedAtPosition(R.id.md_recyclerview_content, 2, R.string.sort_by_start_date)
         assertDisplayedAtPosition(R.id.md_recyclerview_content, 3, R.string.sort_by_end_date)
+        assertDisplayedAtPosition(R.id.md_recyclerview_content, 4, R.string.sort_by_rating)
     }
 }

--- a/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesAdapter.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/list/view/SeriesAdapter.kt
@@ -94,6 +94,7 @@ class SeriesAdapter(
             SortOption.Title -> compareBy { it.title }
             SortOption.StartDate -> compareBy { it.startDate }
             SortOption.EndDate -> compareBy { it.endDate }
+            SortOption.Rating -> compareBy { it.rating }
         }
     )
 }

--- a/libraries/core/src/main/java/com/chesire/nekome/core/flags/SortOption.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/flags/SortOption.kt
@@ -10,7 +10,8 @@ enum class SortOption(val index: Int, @StringRes val stringId: Int) {
     Default(0, R.string.sort_by_default),
     Title(1, R.string.sort_by_title),
     StartDate(2, R.string.sort_by_start_date),
-    EndDate(3, R.string.sort_by_end_date);
+    EndDate(3, R.string.sort_by_end_date),
+    Rating(4, R.string.sort_by_rating);
 
     companion object {
         /**

--- a/libraries/core/src/main/res/values/strings.xml
+++ b/libraries/core/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="sort_by_title">Title</string>
     <string name="sort_by_start_date">Start date</string>
     <string name="sort_by_end_date">End date</string>
+    <string name="sort_by_rating">Rating</string>
 
     <string name="filter_dialog_title">Filter by</string>
     <string name="filter_dialog_cancel">Cancel</string>

--- a/libraries/core/src/test/java/com/chesire/nekome/core/flags/SortOptionTests.kt
+++ b/libraries/core/src/test/java/com/chesire/nekome/core/flags/SortOptionTests.kt
@@ -23,4 +23,9 @@ class SortOptionTests {
     fun `forIndex SortOption#EndDate returns expected value`() {
         assertEquals(SortOption.EndDate, SortOption.forIndex(3))
     }
+
+    @Test
+    fun `forIndex SortOption#Rating returns expected value`() {
+        assertEquals(SortOption.Rating, SortOption.forIndex(4))
+    }
 }


### PR DESCRIPTION
Small change to allow sorting by rating.

Would be nice to choose ascending/descending sort as well, but this was simple enough to do with no experience working on Android.

This was tested in the emulator in Android Studio.