### PR TITLE
fix: failure to get series if no items

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -38,9 +38,6 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="Groovy">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibrary.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/KitsuLibrary.kt
@@ -139,10 +139,7 @@ class KitsuLibrary @Inject constructor(
 
             val body = response.body()
             if (response.isSuccessful && body != null) {
-                val series = body.data.mapNotNull {
-                    map.toSeriesDomain(AddResponseDto(it, body.included))
-                }
-                models.addAll(series)
+                models.addAll(buildSeries(body))
                 retries = 0
 
                 if (body.links.next.isNotEmpty()) {
@@ -164,6 +161,16 @@ class KitsuLibrary @Inject constructor(
             Resource.Error(errorResponse.msg, errorResponse.code)
         } else {
             Resource.Success(models)
+        }
+    }
+
+    private fun buildSeries(body: RetrieveResponseDto): List<SeriesDomain> {
+        return body.data.mapNotNull {
+            if (body.included == null) {
+                null
+            } else {
+                map.toSeriesDomain(AddResponseDto(it, body.included))
+            }
         }
     }
 

--- a/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/RetrieveResponseDto.kt
+++ b/libraries/kitsu/library/src/main/java/com/chesire/nekome/kitsu/library/dto/RetrieveResponseDto.kt
@@ -12,7 +12,7 @@ data class RetrieveResponseDto(
     @Json(name = "data")
     val data: List<DataDto>,
     @Json(name = "included")
-    val included: List<IncludedDto>,
+    val included: List<IncludedDto>?,
     @Json(name = "links")
     val links: Links
 )


### PR DESCRIPTION
If there was no items in a series list (such as anime), then the call to retrieve the series would
fail. Instead make it return an empty list but still a successful request. 
This fixes the issue of if a user has only anime in their library, or only manga.

Fix #746