### PR TITLE
chore: bump gradle from 7.1.3 to 7.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         versionCode 22041422 // Date of build formatted as 'yyMMddHH'
         versionName "1.6.0"
         testInstrumentationRunner "com.chesire.nekome.TestRunner"
-        resConfigs "en", "ja"
+        resConfigs 'en', 'ja'
     }
     buildTypes {
         release {
@@ -50,6 +50,7 @@ android {
         checkAllWarnings true
         checkDependencies true
     }
+    namespace 'com.chesire.nekome'
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome'
     compileSdk sdk_version
 
     defaultConfig {
@@ -50,7 +51,6 @@ android {
         checkAllWarnings true
         checkDependencies true
     }
-    namespace 'com.chesire.nekome'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.chesire.nekome">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath "com.android.tools.build:gradle:7.1.3"
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$aboutlibraries_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath "com.android.tools.build:gradle:7.2.0"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$aboutlibraries_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -26,6 +26,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.discover'
 }
 
 dependencies {

--- a/features/discover/build.gradle
+++ b/features/discover/build.gradle
@@ -8,6 +8,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.discover'
     compileSdk sdk_version
 
     defaultConfig {
@@ -26,7 +27,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.discover'
 }
 
 dependencies {

--- a/features/discover/src/main/AndroidManifest.xml
+++ b/features/discover/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.discover" />
+<manifest />

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.login'
     compileSdk sdk_version
 
     defaultConfig {
@@ -25,7 +26,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.login'
 }
 
 dependencies {

--- a/features/login/build.gradle
+++ b/features/login/build.gradle
@@ -25,6 +25,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.login'
 }
 
 dependencies {

--- a/features/login/src/main/AndroidManifest.xml
+++ b/features/login/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.login" />
+<manifest />

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.profile'
     compileSdk sdk_version
 
     defaultConfig {
@@ -24,7 +25,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.profile'
 }
 
 dependencies {

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -24,6 +24,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.profile'
 }
 
 dependencies {

--- a/features/profile/src/main/AndroidManifest.xml
+++ b/features/profile/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.profile" />
+<manifest />

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -8,6 +8,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.search'
     compileSdk sdk_version
 
     defaultConfig {
@@ -26,7 +27,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.search'
 }
 
 dependencies {

--- a/features/search/build.gradle
+++ b/features/search/build.gradle
@@ -26,6 +26,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.search'
 }
 
 dependencies {

--- a/features/search/src/main/AndroidManifest.xml
+++ b/features/search/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.search" />
+<manifest />

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.series'
     compileSdk sdk_version
 
     defaultConfig {
@@ -25,7 +26,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.series'
 }
 
 dependencies {

--- a/features/series/build.gradle
+++ b/features/series/build.gradle
@@ -25,6 +25,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.series'
 }
 
 dependencies {

--- a/features/series/src/main/AndroidManifest.xml
+++ b/features/series/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.series" />
+<manifest />

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.settings'
     compileSdk sdk_version
 
     defaultConfig {
@@ -22,7 +23,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.app.settings'
 }
 
 dependencies {

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -22,6 +22,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.app.settings'
 }
 
 dependencies {

--- a/features/settings/src/main/AndroidManifest.xml
+++ b/features/settings/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.settings" />
+<manifest />

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.app.timeline'
     compileSdk sdk_version
 
     defaultConfig {
@@ -23,7 +24,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    namespace 'com.chesire.nekome.app.timeline'
 }
 
 dependencies {

--- a/features/timeline/build.gradle
+++ b/features/timeline/build.gradle
@@ -23,6 +23,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.chesire.nekome.app.timeline'
 }
 
 dependencies {

--- a/features/timeline/src/main/AndroidManifest.xml
+++ b/features/timeline/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.app.timeline" />
+<manifest />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -21,6 +21,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.core'
 }
 
 dependencies {

--- a/libraries/core/build.gradle
+++ b/libraries/core/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.core'
     compileSdk sdk_version
 
     defaultConfig {
@@ -21,7 +22,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.core'
 }
 
 dependencies {

--- a/libraries/core/src/main/AndroidManifest.xml
+++ b/libraries/core/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.core" />
+<manifest />

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -33,6 +33,7 @@ android {
     sourceSets {
         test.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+    namespace 'com.chesire.nekome.database'
 }
 
 dependencies {

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.database'
     compileSdk sdk_version
 
     defaultConfig {
@@ -33,7 +34,6 @@ android {
     sourceSets {
         test.assets.srcDirs += files("$projectDir/schemas".toString())
     }
-    namespace 'com.chesire.nekome.database'
 }
 
 dependencies {

--- a/libraries/database/src/main/AndroidManifest.xml
+++ b/libraries/database/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.database" />
+<manifest />

--- a/libraries/datasource/activity/build.gradle
+++ b/libraries/datasource/activity/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.chesire.nekome.datasource.activity'
 }
 
 dependencies {

--- a/libraries/datasource/activity/build.gradle
+++ b/libraries/datasource/activity/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.activity'
     compileSdk sdk_version
 
     defaultConfig {
@@ -18,7 +19,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    namespace 'com.chesire.nekome.datasource.activity'
 }
 
 dependencies {

--- a/libraries/datasource/activity/src/main/AndroidManifest.xml
+++ b/libraries/datasource/activity/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.datasource.activity" />
+<manifest />

--- a/libraries/datasource/auth/build.gradle
+++ b/libraries/datasource/auth/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.auth'
     compileSdk sdk_version
 
     defaultConfig {
@@ -19,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.datasource.auth'
 }
 
 dependencies {

--- a/libraries/datasource/auth/build.gradle
+++ b/libraries/datasource/auth/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.datasource.auth'
 }
 
 dependencies {

--- a/libraries/datasource/auth/src/main/AndroidManifest.xml
+++ b/libraries/datasource/auth/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools"
-    package="com.chesire.nekome.datasource.auth">
+<manifest xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="androidx.security" />
 </manifest>

--- a/libraries/datasource/search/build.gradle
+++ b/libraries/datasource/search/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.search'
     compileSdk sdk_version
 
     defaultConfig {
@@ -19,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.datasource.search'
 }
 
 dependencies {

--- a/libraries/datasource/search/build.gradle
+++ b/libraries/datasource/search/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.datasource.search'
 }
 
 dependencies {

--- a/libraries/datasource/search/src/main/AndroidManifest.xml
+++ b/libraries/datasource/search/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.datasource.search" />
+<manifest />

--- a/libraries/datasource/series/build.gradle
+++ b/libraries/datasource/series/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.series'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.datasource.series'
 }
 
 dependencies {

--- a/libraries/datasource/series/build.gradle
+++ b/libraries/datasource/series/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.datasource.series'
 }
 
 dependencies {

--- a/libraries/datasource/series/src/main/AndroidManifest.xml
+++ b/libraries/datasource/series/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.datasource.series" />
+<manifest />

--- a/libraries/datasource/trending/build.gradle
+++ b/libraries/datasource/trending/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.datasource.trending'
 }
 
 dependencies {

--- a/libraries/datasource/trending/build.gradle
+++ b/libraries/datasource/trending/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.trending'
     compileSdk sdk_version
 
     defaultConfig {
@@ -19,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.datasource.trending'
 }
 
 dependencies {

--- a/libraries/datasource/trending/src/main/AndroidManifest.xml
+++ b/libraries/datasource/trending/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.datasource.trending" />
+<manifest />

--- a/libraries/datasource/user/build.gradle
+++ b/libraries/datasource/user/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.datasource.user'
 }
 
 dependencies {

--- a/libraries/datasource/user/build.gradle
+++ b/libraries/datasource/user/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.datasource.user'
     compileSdk sdk_version
 
     defaultConfig {
@@ -19,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.datasource.user'
 }
 
 dependencies {

--- a/libraries/datasource/user/src/main/AndroidManifest.xml
+++ b/libraries/datasource/user/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.datasource.user" />
+<manifest />

--- a/libraries/kitsu/activity/build.gradle
+++ b/libraries/kitsu/activity/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.activity'
 }
 
 dependencies {

--- a/libraries/kitsu/activity/build.gradle
+++ b/libraries/kitsu/activity/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.activity'
     compileSdk sdk_version
 
     defaultConfig {
@@ -19,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.activity'
 }
 
 dependencies {

--- a/libraries/kitsu/activity/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/activity/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.chesire.nekome.kitsu.activity" />
+<manifest />

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.auth'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.auth'
 }
 
 dependencies {

--- a/libraries/kitsu/auth/build.gradle
+++ b/libraries/kitsu/auth/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.auth'
 }
 
 dependencies {

--- a/libraries/kitsu/auth/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/auth/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome.kitsu.auth">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu'
 }
 
 dependencies {

--- a/libraries/kitsu/build.gradle
+++ b/libraries/kitsu/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu'
 }
 
 dependencies {

--- a/libraries/kitsu/library/build.gradle
+++ b/libraries/kitsu/library/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.library'
 }
 
 dependencies {

--- a/libraries/kitsu/library/build.gradle
+++ b/libraries/kitsu/library/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.library'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.library'
 }
 
 dependencies {

--- a/libraries/kitsu/library/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/library/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome.kitsu.library">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/libraries/kitsu/search/build.gradle
+++ b/libraries/kitsu/search/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.search'
 }
 
 dependencies {

--- a/libraries/kitsu/search/build.gradle
+++ b/libraries/kitsu/search/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.search'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.search'
 }
 
 dependencies {

--- a/libraries/kitsu/search/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/search/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome.kitsu.search">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/libraries/kitsu/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.kitsu" />
+<manifest />

--- a/libraries/kitsu/trending/build.gradle
+++ b/libraries/kitsu/trending/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.trending'
 }
 
 dependencies {

--- a/libraries/kitsu/trending/build.gradle
+++ b/libraries/kitsu/trending/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.trending'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.trending'
 }
 
 dependencies {

--- a/libraries/kitsu/trending/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/trending/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome.kitsu.trending">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/libraries/kitsu/user/build.gradle
+++ b/libraries/kitsu/user/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
+    namespace 'com.chesire.nekome.kitsu.user'
 }
 
 dependencies {

--- a/libraries/kitsu/user/build.gradle
+++ b/libraries/kitsu/user/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.kitsu.user'
     compileSdk sdk_version
 
     defaultConfig {
@@ -20,7 +21,6 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    namespace 'com.chesire.nekome.kitsu.user'
 }
 
 dependencies {

--- a/libraries/kitsu/user/src/main/AndroidManifest.xml
+++ b/libraries/kitsu/user/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.nekome.kitsu.user">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.chesire.nekome.testing'
     compileSdk sdk_version
 
     defaultConfig {
@@ -24,7 +25,6 @@ android {
             excludes += ['META-INF/AL2.0', 'META-INF/LGPL2.1', 'META-INF/*.kotlin_module']
         }
     }
-    namespace 'com.chesire.nekome.testing'
 }
 
 dependencies {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -24,6 +24,7 @@ android {
             excludes += ['META-INF/AL2.0', 'META-INF/LGPL2.1', 'META-INF/*.kotlin_module']
         }
     }
+    namespace 'com.chesire.nekome.testing'
 }
 
 dependencies {

--- a/testing/src/main/AndroidManifest.xml
+++ b/testing/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.chesire.nekome.testing" />
+<manifest />


### PR DESCRIPTION
Bumps the Gradle version from 7.1.3 to 7.2.0 and makes suggested changes based on the gradle upgrade wizard.