### PR TITLE
fix: issue with creating encrypted preferences

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core = { module = "androidx.core:core-ktx", version = "1.9.0" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.5.4" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
-androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref= "androidx-hilt" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
 androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version = "2.2.0" }
 androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version = "2.5.1" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version = "2.5.1" }
@@ -34,7 +34,7 @@ androidx-room = { module = "androidx.room:room-ktx", version.ref = "androidx-roo
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
-androidx-security-crypto = { module = "androidx.security:security-crypto", version = "1.0.0" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version = "1.1.0-alpha04" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version = "1.1.0" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-espresso" }

--- a/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
+++ b/libraries/datasource/auth/src/main/java/com/chesire/nekome/datasource/auth/local/PreferenceProvider.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
+import androidx.security.crypto.MasterKey
 import com.chesire.nekome.core.extensions.migrateTo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -36,9 +36,9 @@ class PreferenceProvider @Inject constructor(@ApplicationContext private val con
 
     private fun initEncryptedPreferences(storeName: String) =
         EncryptedSharedPreferences.create(
-            storeName,
-            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
             context,
+            storeName,
+            MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )


### PR DESCRIPTION
When creating the encrypted preferences, sometimes it will fail and crash. It looks like this could be an issue with the tink library that google makes use of which is updated in later dependency versions. Updating to the latest should hopefully fix it.