### PR TITLE
ci: update the ruby github action

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -56,20 +56,10 @@ jobs:
       run: ./gradlew :app:lint
     - name: run detektCheck
       run: ./gradlew detektCheck
-    - uses: actions/setup-ruby@v1.1.3
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: bundle install
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --without=documentation --jobs 4 --retry 3
+        bundler-cache: true
     - name: danger
       run: bundle exec danger
       env:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -58,7 +58,7 @@ jobs:
       run: ./gradlew detektCheck
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.6'
+        ruby-version: '2.7'
         bundler-cache: true
     - name: danger
       run: bundle exec danger


### PR DESCRIPTION
Update the ruby action to use the non-deprecated one, and updated the version to 2.7