### PR TITLE
fix: stop the no series found text from showing on start

### DIFF
--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -155,14 +156,18 @@ private fun Render(
         },
         modifier = Modifier.semantics { testTag = SeriesCollectionTags.Root }
     ) { paddingValues ->
-        SeriesCollection(
-            models = state.value.models,
-            isRefreshing = state.value.isRefreshing,
-            modifier = Modifier.padding(paddingValues),
-            onRefresh = onRefresh,
-            onSelectSeries = onSelectSeries,
-            onIncrementSeries = onIncrementSeries
-        )
+        if (state.value.isInitializing) {
+            CircularProgressIndicator()
+        } else {
+            SeriesCollection(
+                models = state.value.models,
+                isRefreshing = state.value.isRefreshing,
+                modifier = Modifier.padding(paddingValues),
+                onRefresh = onRefresh,
+                onSelectSeries = onSelectSeries,
+                onIncrementSeries = onIncrementSeries
+            )
+        }
     }
 
     SortDialog(
@@ -395,6 +400,7 @@ private fun RenderSnackbar(
 private fun Preview() {
     val initialState = UIState(
         screenTitle = R.string.nav_anime,
+        isInitializing = true,
         models = listOf(
             Series(
                 userId = 0,

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModel.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModel.kt
@@ -33,8 +33,6 @@ import kotlinx.coroutines.launch
 // Note this value is pulled from the nav_graph.xml
 private const val SERIES_TYPE = "seriesType"
 
-// TODO: Show a "loading" screen, which should be a list of shimmering items
-
 @HiltViewModel
 class CollectionViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -74,7 +72,10 @@ class CollectionViewModel @Inject constructor(
                 .flatMapLatest { sortSeries(it) }
                 .map(domainMapper::toSeries)
                 .collect { newModels ->
-                    state = state.copy(models = newModels)
+                    state = state.copy(
+                        isInitializing = false,
+                        models = newModels
+                    )
                 }
         }
     }
@@ -89,6 +90,7 @@ class CollectionViewModel @Inject constructor(
                 action.series,
                 action.rating
             )
+
             ViewAction.SortPressed -> handleSortPressed()
             is ViewAction.PerformSort -> handlePerformSort(action.option)
             ViewAction.FilterPressed -> handleFilterPressed()

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/UIState.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/UIState.kt
@@ -6,6 +6,7 @@ import com.chesire.nekome.core.preferences.flags.SortOption
 
 data class UIState(
     @StringRes val screenTitle: Int,
+    val isInitializing: Boolean,
     val models: List<Series>,
     val isRefreshing: Boolean,
     val ratingDialog: Rating?,
@@ -17,6 +18,7 @@ data class UIState(
     companion object {
         val default = UIState(
             screenTitle = R.string.nav_anime,
+            isInitializing = true,
             models = emptyList(),
             isRefreshing = false,
             ratingDialog = null,


### PR DESCRIPTION
Add a flag to indicate if the screen is initalizing so we can wait until its initialized to show if there are no series found.