### PR TITLE
fix: make use of the user setting for theme

### DIFF
--- a/app/src/main/java/com/chesire/nekome/ui/MainActivity.kt
+++ b/app/src/main/java/com/chesire/nekome/ui/MainActivity.kt
@@ -3,21 +3,50 @@ package com.chesire.nekome.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.collectAsState
 import com.chesire.lifecyklelog.LogLifecykle
 import com.chesire.nekome.core.compose.theme.NekomeTheme
+import com.chesire.nekome.core.preferences.ApplicationPreferences
+import com.chesire.nekome.core.preferences.flags.Theme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @LogLifecykle
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    @Inject
+    lateinit var appSettings: ApplicationPreferences
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            NekomeTheme {
+            val themeState = appSettings.theme.collectAsState(initial = Theme.System)
+            val (isDarkMode, isDynamicColor) = generateTheme(
+                theme = themeState.value,
+                isSystemDarkMode = isSystemInDarkTheme()
+            )
+            NekomeTheme(
+                isDarkTheme = isDarkMode,
+                isDynamicColor = isDynamicColor
+            ) {
                 MainActivityScreen()
             }
+        }
+    }
+
+    /**
+     * Returns a [Pair] of (dark mode enabled) to (dynamic color enabled).
+     */
+    private fun generateTheme(theme: Theme, isSystemDarkMode: Boolean): Pair<Boolean, Boolean> {
+        return when (theme) {
+            Theme.System -> isSystemDarkMode to true
+            Theme.Dark -> true to false
+            Theme.Light -> false to false
+            Theme.DynamicDark -> true to true
+            Theme.DynamicLight -> false to true
         }
     }
 }

--- a/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/Theme.kt
+++ b/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/Theme.kt
@@ -2,16 +2,17 @@ package com.chesire.nekome.core.preferences.flags
 
 import android.content.Context
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatDelegate
 import com.chesire.nekome.core.R
 
 /**
  * Themes that the application can be to set to use.
  */
 enum class Theme(val value: Int, @StringRes val stringId: Int) {
-    System(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, R.string.settings_theme_system),
-    Dark(AppCompatDelegate.MODE_NIGHT_YES, R.string.settings_theme_dark),
-    Light(AppCompatDelegate.MODE_NIGHT_NO, R.string.settings_theme_light);
+    System(-1, R.string.settings_theme_system),
+    Dark(2, R.string.settings_theme_dark),
+    Light(1, R.string.settings_theme_light),
+    DynamicDark(3, R.string.settings_theme_dynamic_dark),
+    DynamicLight(4, R.string.settings_theme_dynamic_light);
 
     companion object {
         /**

--- a/core/preferences/src/test/java/com/chesire/nekome/core/preferences/flags/ThemeTests.kt
+++ b/core/preferences/src/test/java/com/chesire/nekome/core/preferences/flags/ThemeTests.kt
@@ -8,18 +8,23 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ThemeTests {
+
     @Test
     fun `getValueMap returns expected map`() {
         val mockContext = mockk<Context> {
             every { getString(R.string.settings_theme_system) } returns "system"
             every { getString(R.string.settings_theme_dark) } returns "dark"
             every { getString(R.string.settings_theme_light) } returns "light"
+            every { getString(R.string.settings_theme_dynamic_dark) } returns "dynamicDark"
+            every { getString(R.string.settings_theme_dynamic_light) } returns "dynamicLight"
         }
         val map = Theme.getValueMap(mockContext)
 
         assertEquals("system", map.getValue(-1))
         assertEquals("dark", map.getValue(2))
         assertEquals("light", map.getValue(1))
+        assertEquals("dynamicDark", map.getValue(3))
+        assertEquals("dynamicLight", map.getValue(4))
     }
 
     @Test
@@ -43,6 +48,22 @@ class ThemeTests {
         assertEquals(
             Theme.Light,
             Theme.fromValue("1")
+        )
+    }
+
+    @Test
+    fun `fromValue with Theme#DynamicDark returns expected value`() {
+        assertEquals(
+            Theme.DynamicDark,
+            Theme.fromValue("3")
+        )
+    }
+
+    @Test
+    fun `fromValue with Theme#DynamicLight returns expected value`() {
+        assertEquals(
+            Theme.DynamicLight,
+            Theme.fromValue("4")
         )
     }
 

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -117,6 +117,8 @@
     <string name="settings_theme_system">システムのデフォルト</string>
     <string name="settings_theme_dark">ダークテーマ</string>
     <string name="settings_theme_light">ライトテーマ</string>
+    <string name="settings_theme_dynamic_dark">ダイナミックダークテーマ</string>
+    <string name="settings_theme_dynamic_light">ダイナミックライトテーマ</string>
 
     <string name="discover_trending_anime">流行中のアニメ</string>
     <string name="discover_trending_manga">流行中の漫画</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="settings_theme_system">Use system default</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dynamic_dark">Dynamic Dark</string>
+    <string name="settings_theme_dynamic_light">Dynamic Light</string>
 
     <string name="discover_trending_anime">Trending Anime</string>
     <string name="discover_trending_manga">Trending Manga</string>


### PR DESCRIPTION
Add user settings for dynamic themes, and make use of them when loading the app.