### PR TITLE
fix: crash when user object is gone

### DIFF
--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModel.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModel.kt
@@ -43,20 +43,24 @@ class ConfigViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val user = retrieveUser().first()
-            check(user is User.Found)
-            state = state.copy(
-                userModel = UserModel(
-                    avatarUrl = user.domain.avatar.largest?.url ?: "",
-                    userName = user.domain.name
-                )
-            )
-            retrievePreferences().collect { prefModel ->
+            if (user !is User.Found) {
+                // If no user is found, we should log the user out of the app.
+                handleOnLogoutResult(true)
+            } else {
                 state = state.copy(
-                    themeValue = prefModel.theme,
-                    defaultHomeValue = prefModel.defaultHomeScreen,
-                    defaultSeriesStatusValue = prefModel.defaultSeriesStatus,
-                    rateSeriesValue = prefModel.shouldRateSeries
+                    userModel = UserModel(
+                        avatarUrl = user.domain.avatar.largest?.url ?: "",
+                        userName = user.domain.name
+                    )
                 )
+                retrievePreferences().collect { prefModel ->
+                    state = state.copy(
+                        themeValue = prefModel.theme,
+                        defaultHomeValue = prefModel.defaultHomeScreen,
+                        defaultSeriesStatusValue = prefModel.defaultSeriesStatus,
+                        rateSeriesValue = prefModel.shouldRateSeries
+                    )
+                }
             }
         }
     }
@@ -71,9 +75,11 @@ class ConfigViewModel @Inject constructor(
             ViewAction.OnDefaultHomeScreenClicked -> handleOnDefaultHomeScreenClicked()
             is ViewAction.OnDefaultHomeScreenChanged ->
                 handleOnDefaultHomeScreenChanged(action.newHomeScreen)
+
             ViewAction.OnDefaultSeriesStatusClicked -> handleOnDefaultSeriesStatusClicked()
             is ViewAction.OnDefaultSeriesStatusChanged ->
                 handleOnDefaultSeriesStatusChanged(action.newDefaultSeriesStatus)
+
             is ViewAction.OnRateSeriesChanged -> handleOnRateSeriesChanged(action.newValue)
         }
     }


### PR DESCRIPTION
If the user object has been remove somehow, then the user will crash every time they open the config view. Instead execute a log out for the user so they can then log back in.