### PR TITLE
test: remove usage of uninstall modules

### DIFF
--- a/app/src/androidTest/java/com/chesire/nekome/UITest.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/UITest.kt
@@ -1,5 +1,6 @@
 package com.chesire.nekome
 
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.adevinta.android.barista.rule.cleardata.ClearDatabaseRule
@@ -36,6 +37,9 @@ abstract class UITest {
 
     @get:Rule
     val clearPreferences = ClearPreferencesRule()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     @Inject
     lateinit var authProvider: AuthProvider

--- a/app/src/androidTest/java/com/chesire/nekome/features/ActivityTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/ActivityTests.kt
@@ -1,19 +1,14 @@
 package com.chesire.nekome.features
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
 import com.chesire.nekome.robots.activity
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class ActivityTests : UITest() {
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     @Test
     fun overviewCanStartInAnimeView() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/CredentialsTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/CredentialsTests.kt
@@ -1,31 +1,22 @@
 package com.chesire.nekome.features.login
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.datasource.auth.remote.AuthApi
 import com.chesire.nekome.datasource.auth.remote.AuthFailure
-import com.chesire.nekome.injection.AuthModule
 import com.chesire.nekome.robots.login.loginCredentials
 import com.github.michaelbull.result.Err
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
-import io.mockk.mockk
-import org.junit.Rule
+import javax.inject.Inject
 import org.junit.Test
 
 @HiltAndroidTest
-@UninstallModules(AuthModule::class)
 class CredentialsTests : UITest() {
 
     override val startLoggedIn = false
 
-    @BindValue
-    val authApi = mockk<AuthApi>()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    @Inject
+    lateinit var authApi: AuthApi
 
     @Test
     fun emptyUsernameShowsError() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
@@ -7,26 +7,17 @@ import com.chesire.nekome.datasource.series.remote.SeriesApi
 import com.chesire.nekome.datasource.user.remote.UserApi
 import com.chesire.nekome.helpers.creation.createSeriesDomain
 import com.chesire.nekome.helpers.creation.createUserDomain
-import com.chesire.nekome.injection.LibraryModule
-import com.chesire.nekome.injection.UserModule
 import com.chesire.nekome.robots.activity
 import com.chesire.nekome.robots.login.loginCredentials
 import com.chesire.nekome.robots.login.loginSyncing
 import com.github.michaelbull.result.Ok
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
-import io.mockk.mockk
 import javax.inject.Inject
 import org.junit.Before
 import org.junit.Test
 
 @HiltAndroidTest
-@UninstallModules(
-    LibraryModule::class,
-    UserModule::class
-)
 class LoginFlowTests : UITest() {
 
     override val startLoggedIn = false
@@ -34,28 +25,11 @@ class LoginFlowTests : UITest() {
     @Inject
     lateinit var authApi: AuthApi
 
-    @BindValue
-    val seriesApi = mockk<SeriesApi> {
-        coEvery {
-            retrieveAnime(any())
-        } coAnswers {
-            Ok(listOf(createSeriesDomain()))
-        }
-        coEvery {
-            retrieveManga(any())
-        } coAnswers {
-            Ok(listOf(createSeriesDomain()))
-        }
-    }
+    @Inject
+    lateinit var seriesApi: SeriesApi
 
-    @BindValue
-    val userApi = mockk<UserApi> {
-        coEvery {
-            getUserDetails()
-        } coAnswers {
-            Ok(createUserDomain())
-        }
-    }
+    @Inject
+    lateinit var userApi: UserApi
 
     @Before
     fun setup() {
@@ -63,6 +37,23 @@ class LoginFlowTests : UITest() {
             authApi.login("Username", "Password")
         } coAnswers {
             Ok(AuthDomain("accessToken", "refreshToken"))
+        }
+
+        coEvery {
+            seriesApi.retrieveAnime(any())
+        } coAnswers {
+            Ok(listOf(createSeriesDomain()))
+        }
+        coEvery {
+            seriesApi.retrieveManga(any())
+        } coAnswers {
+            Ok(listOf(createSeriesDomain()))
+        }
+
+        coEvery {
+            userApi.getUserDetails()
+        } coAnswers {
+            Ok(createUserDomain())
         }
     }
 

--- a/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/login/LoginFlowTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.features.login
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.datasource.auth.remote.AuthApi
 import com.chesire.nekome.datasource.auth.remote.AuthDomain
@@ -8,7 +7,6 @@ import com.chesire.nekome.datasource.series.remote.SeriesApi
 import com.chesire.nekome.datasource.user.remote.UserApi
 import com.chesire.nekome.helpers.creation.createSeriesDomain
 import com.chesire.nekome.helpers.creation.createUserDomain
-import com.chesire.nekome.injection.AuthModule
 import com.chesire.nekome.injection.LibraryModule
 import com.chesire.nekome.injection.UserModule
 import com.chesire.nekome.robots.activity
@@ -20,12 +18,12 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
 import io.mockk.mockk
-import org.junit.Rule
+import javax.inject.Inject
+import org.junit.Before
 import org.junit.Test
 
 @HiltAndroidTest
 @UninstallModules(
-    AuthModule::class,
     LibraryModule::class,
     UserModule::class
 )
@@ -33,14 +31,8 @@ class LoginFlowTests : UITest() {
 
     override val startLoggedIn = false
 
-    @BindValue
-    val authApi = mockk<AuthApi> {
-        coEvery {
-            login("Username", "Password")
-        } coAnswers {
-            Ok(AuthDomain("accessToken", "refreshToken"))
-        }
-    }
+    @Inject
+    lateinit var authApi: AuthApi
 
     @BindValue
     val seriesApi = mockk<SeriesApi> {
@@ -65,8 +57,14 @@ class LoginFlowTests : UITest() {
         }
     }
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    @Before
+    fun setup() {
+        coEvery {
+            authApi.login("Username", "Password")
+        } coAnswers {
+            Ok(AuthDomain("accessToken", "refreshToken"))
+        }
+    }
 
     @Test
     fun navigateThroughLoginFlow() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/search/SearchTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/search/SearchTests.kt
@@ -3,34 +3,34 @@ package com.chesire.nekome.features.search
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.models.ErrorDomain
 import com.chesire.nekome.datasource.search.remote.SearchApi
-import com.chesire.nekome.injection.SearchModule
 import com.chesire.nekome.robots.activity
 import com.chesire.nekome.robots.search.host
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
-import io.mockk.mockk
+import javax.inject.Inject
+import org.junit.Before
 import org.junit.Test
 
 private const val GENERIC_ERROR = "GENERIC_ERROR"
 private const val NO_RESULTS_ERROR = "NO_RESULTS_ERROR"
 
 @HiltAndroidTest
-@UninstallModules(SearchModule::class)
 class SearchTests : UITest() {
 
-    @BindValue
-    val searchApi = mockk<SearchApi> {
+    @Inject
+    lateinit var searchApi: SearchApi
+
+    @Before
+    fun setup() {
         coEvery {
-            searchForAnime(GENERIC_ERROR)
+            searchApi.searchForAnime(GENERIC_ERROR)
         } coAnswers {
             Err(ErrorDomain.badRequest)
         }
         coEvery {
-            searchForAnime(NO_RESULTS_ERROR)
+            searchApi.searchForAnime(NO_RESULTS_ERROR)
         } coAnswers {
             Ok(listOf())
         }

--- a/app/src/androidTest/java/com/chesire/nekome/features/search/SearchTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/search/SearchTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.features.search
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.models.ErrorDomain
 import com.chesire.nekome.datasource.search.remote.SearchApi
@@ -14,7 +13,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
 import io.mockk.mockk
-import org.junit.Rule
 import org.junit.Test
 
 private const val GENERIC_ERROR = "GENERIC_ERROR"
@@ -37,9 +35,6 @@ class SearchTests : UITest() {
             Ok(listOf())
         }
     }
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     @Test
     fun canReachSearch() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/series/FilterTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/FilterTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.features.series
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
@@ -9,16 +8,12 @@ import com.chesire.nekome.robots.series.seriesList
 import com.chesire.nekome.testing.createSeriesEntity
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class FilterTests : UITest() {
 
     private val seriesData = InitialFilterSeriesData()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     override fun setUp() {
         super.setUp()

--- a/app/src/androidTest/java/com/chesire/nekome/features/series/SeriesListTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/SeriesListTests.kt
@@ -6,25 +6,21 @@ import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.ErrorDomain
 import com.chesire.nekome.datasource.series.remote.SeriesApi
 import com.chesire.nekome.helpers.creation.createSeriesDomain
-import com.chesire.nekome.injection.LibraryModule
 import com.chesire.nekome.robots.series.seriesList
 import com.chesire.nekome.testing.createSeriesEntity
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
-import io.mockk.mockk
+import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 @HiltAndroidTest
-@UninstallModules(LibraryModule::class)
 class SeriesListTests : UITest() {
 
-    @BindValue
-    val seriesApi = mockk<SeriesApi>()
+    @Inject
+    lateinit var seriesApi: SeriesApi
 
     @Test
     fun canReachSeriesList() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/series/SeriesListTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/SeriesListTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.features.series
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
@@ -18,7 +17,6 @@ import dagger.hilt.android.testing.UninstallModules
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
@@ -27,9 +25,6 @@ class SeriesListTests : UITest() {
 
     @BindValue
     val seriesApi = mockk<SeriesApi>()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     @Test
     fun canReachSeriesList() {

--- a/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/series/SortTests.kt
@@ -1,6 +1,5 @@
 package com.chesire.nekome.features.series
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.UserSeriesStatus
@@ -9,16 +8,12 @@ import com.chesire.nekome.robots.series.seriesList
 import com.chesire.nekome.testing.createSeriesEntity
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class SortTests : UITest() {
 
     private val seriesData = InitialSortSeriesData()
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     override fun setUp() {
         super.setUp()

--- a/app/src/androidTest/java/com/chesire/nekome/features/settings/SettingsTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/settings/SettingsTests.kt
@@ -1,18 +1,13 @@
 package com.chesire.nekome.features.settings
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import com.chesire.nekome.UITest
 import com.chesire.nekome.robots.activity
 import com.chesire.nekome.robots.settings.config
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class SettingsTests : UITest() {
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     @Test
     fun canReachSettings() {

--- a/app/src/androidTest/java/com/chesire/nekome/injection/MockAuthModule.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/injection/MockAuthModule.kt
@@ -1,0 +1,21 @@
+package com.chesire.nekome.injection
+
+import com.chesire.nekome.datasource.auth.remote.AuthApi
+import dagger.Module
+import dagger.Provides
+import dagger.Reusable
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import io.mockk.mockk
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [AuthModule::class]
+)
+class MockAuthModule {
+
+    @Provides
+    @Reusable
+    fun provideAuthApi(): AuthApi = mockk<AuthApi>()
+}

--- a/app/src/androidTest/java/com/chesire/nekome/injection/MockLibraryModule.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/injection/MockLibraryModule.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.injection
 
-import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.series.remote.SeriesApi
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -11,11 +11,11 @@ import io.mockk.mockk
 @Module
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [AuthModule::class]
+    replaces = [LibraryModule::class]
 )
-class MockAuthModule {
+class MockLibraryModule {
 
     @Provides
     @Reusable
-    fun provideApi() = mockk<AuthApi>()
+    fun provideApi() = mockk<SeriesApi>()
 }

--- a/app/src/androidTest/java/com/chesire/nekome/injection/MockSearchModule.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/injection/MockSearchModule.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.injection
 
-import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.search.remote.SearchApi
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -11,11 +11,11 @@ import io.mockk.mockk
 @Module
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [AuthModule::class]
+    replaces = [SearchModule::class]
 )
-class MockAuthModule {
+class MockSearchModule {
 
     @Provides
     @Reusable
-    fun provideApi() = mockk<AuthApi>()
+    fun provideApi() = mockk<SearchApi>()
 }

--- a/app/src/androidTest/java/com/chesire/nekome/injection/MockUserModule.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/injection/MockUserModule.kt
@@ -1,6 +1,6 @@
 package com.chesire.nekome.injection
 
-import com.chesire.nekome.datasource.auth.remote.AuthApi
+import com.chesire.nekome.datasource.user.remote.UserApi
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -11,11 +11,11 @@ import io.mockk.mockk
 @Module
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [AuthModule::class]
+    replaces = [UserModule::class]
 )
-class MockAuthModule {
+class MockUserModule {
 
     @Provides
     @Reusable
-    fun provideApi() = mockk<AuthApi>()
+    fun provideApi() = mockk<UserApi>()
 }

--- a/app/src/main/java/com/chesire/nekome/injection/DatabaseModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/DatabaseModule.kt
@@ -17,6 +17,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
+
     /**
      * Provides the build [RoomDB].
      */

--- a/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/ServerModule.kt
@@ -17,6 +17,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 @Module
 @InstallIn(SingletonComponent::class)
 object ServerModule {
+
     /**
      * Provides an instance of [OkHttpClient] with the authentication injectors pre-setup, so that
      * authentication is already handled.

--- a/app/src/main/java/com/chesire/nekome/injection/TrendingModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/TrendingModule.kt
@@ -27,6 +27,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 abstract class TrendingModule {
 
     companion object {
+
         /**
          * Builds and provides the instance of [KitsuTrendingService].
          */

--- a/app/src/main/java/com/chesire/nekome/injection/UserModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/UserModule.kt
@@ -25,6 +25,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 abstract class UserModule {
 
     companion object {
+
         /**
          * Builds and provides the instance of [KitsuUserService].
          */

--- a/app/src/main/java/com/chesire/nekome/injection/WorkerModule.kt
+++ b/app/src/main/java/com/chesire/nekome/injection/WorkerModule.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 @Module
 @InstallIn(SingletonComponent::class)
 object WorkerModule {
+
     /**
      * Provides a [WorkManager] instance to the dependency graph.
      */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ detekt = "1.23.0-RC3"
 hilt = "2.45"
 kotlin = "1.8.20"
 kotlin-coroutines = "1.6.4"
+mockk = "1.13.3"
 moshi = "1.14.0"
 okhttp3 = "4.11.0"
 retrofit = "2.9.0"
@@ -73,8 +74,8 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version = "1.1.17" }
 lifecyklelog = { module = "com.github.chesire:lifecyklelog", version = "3.1.1" }
-mockk = { module = "io.mockk:mockk", version = "1.13.5" }
-mockk-android = { module = "io.mockk:mockk-android", version = "1.13.5" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.10" }
 squareup-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.10" }
 squareup-moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }


### PR DESCRIPTION
Remove the usage of `UninstallModules` in tests since it is bad performance, and instead use `TestInstallIn` for all of the APIs.