### PR TITLE
feat: add option to change image quality

### DIFF
--- a/app/src/androidTest/java/com/chesire/nekome/features/settings/SettingsTests.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/features/settings/SettingsTests.kt
@@ -119,6 +119,44 @@ class SettingsTests : UITest() {
     }
 
     @Test
+    fun changeImageQuality() {
+        launchActivity()
+
+        activity(composeTestRule) {
+            goToSettings()
+        }
+        config(composeTestRule) {
+            clickImageQuality()
+
+            imageQuality {
+                validate {
+                    isLoadedCorrectly()
+                }
+            }
+
+            imageQuality {
+                chooseHigh()
+                validate {
+                    highIsSelected()
+                }
+                confirm()
+            }
+
+            clickImageQuality()
+            imageQuality {
+                validate {
+                    highIsSelected()
+                }
+                chooseMedium()
+                validate {
+                    mediumIsSelected()
+                }
+                confirm()
+            }
+        }
+    }
+
+    @Test
     fun changeThemeSetting() {
         launchActivity()
 

--- a/app/src/androidTest/java/com/chesire/nekome/robots/settings/ConfigRobot.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/robots/settings/ConfigRobot.kt
@@ -50,6 +50,22 @@ class ConfigRobot(private val composeContentTestRule: ComposeContentTestRule) {
     fun defaultHomeScreen(func: DefaultHomeScreenRobot.() -> Unit) =
         DefaultHomeScreenRobot(composeContentTestRule).apply(func)
 
+
+    /**
+     * Opens the image quality dialog.
+     */
+    fun clickImageQuality() {
+        composeContentTestRule
+            .onNodeWithText(R.string.settings_image_quality_title.getResource())
+            .performClick()
+    }
+
+    /**
+     * Options for selecting the image quality.
+     */
+    fun imageQuality(func: ImageQualityRobot.() -> Unit) =
+        ImageQualityRobot(composeContentTestRule).apply(func)
+
     /**
      * Opens the theme dialog.
      */

--- a/app/src/androidTest/java/com/chesire/nekome/robots/settings/ConfigRobot.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/robots/settings/ConfigRobot.kt
@@ -50,7 +50,6 @@ class ConfigRobot(private val composeContentTestRule: ComposeContentTestRule) {
     fun defaultHomeScreen(func: DefaultHomeScreenRobot.() -> Unit) =
         DefaultHomeScreenRobot(composeContentTestRule).apply(func)
 
-
     /**
      * Opens the image quality dialog.
      */

--- a/app/src/androidTest/java/com/chesire/nekome/robots/settings/ImageQualityRobot.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/robots/settings/ImageQualityRobot.kt
@@ -1,0 +1,101 @@
+package com.chesire.nekome.robots.settings
+
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.chesire.nekome.core.compose.composables.DialogTags
+import com.chesire.nekome.core.preferences.flags.ImageQuality
+import com.chesire.nekome.helpers.getResource
+import com.chesire.nekome.robots.DialogResultsRobot
+import com.chesire.nekome.robots.DialogRobot
+
+
+class ImageQualityRobot(
+    private val composeContentTestRule: ComposeContentTestRule
+) : DialogRobot(composeContentTestRule) {
+
+    /**
+     * Picks the "Low" option.
+     */
+    fun chooseLow() {
+        composeContentTestRule
+            .onNodeWithText(ImageQuality.Low.stringId.getResource())
+            .performClick()
+    }
+
+    /**
+     * Picks the "Medium" option.
+     */
+    fun chooseMedium() {
+        composeContentTestRule
+            .onNodeWithText(ImageQuality.Medium.stringId.getResource())
+            .performClick()
+    }
+
+    /**
+     * Picks the "High" option.
+     */
+    fun chooseHigh() {
+        composeContentTestRule
+            .onNodeWithText(ImageQuality.High.stringId.getResource())
+            .performClick()
+    }
+
+    /**
+     * Executes validation steps.
+     * Requires opening the dialog, performing the check, then closing the dialog again.
+     */
+    infix fun validate(func: ImageQualityResultRobot.() -> Unit) =
+        ImageQualityResultRobot(composeContentTestRule).apply(func)
+}
+
+/**
+ * Robot to check the results for the default series state dialog.
+ */
+class ImageQualityResultRobot(
+    private val composeContentTestRule: ComposeContentTestRule
+) : DialogResultsRobot(composeContentTestRule) {
+
+    /**
+     * Assert that the options are in the correct locations.
+     */
+    fun isLoadedCorrectly() {
+        val collection = composeContentTestRule.onAllNodesWithTag(DialogTags.OptionText, true)
+        collection[0].assertTextContains(ImageQuality.Low.stringId.getResource())
+        collection[1].assertTextContains(ImageQuality.Medium.stringId.getResource())
+        collection[2].assertTextContains(ImageQuality.High.stringId.getResource())
+    }
+
+    /**
+     * Checks if the "Low" option is checked.
+     */
+    fun lowIsSelected() {
+        composeContentTestRule
+            .onAllNodesWithTag(DialogTags.OptionRadio, true)
+            .get(0)
+            .assertIsSelected()
+    }
+
+    /**
+     * Checks if the "Medium" option is checked.
+     */
+    fun mediumIsSelected() {
+        composeContentTestRule
+            .onAllNodesWithTag(DialogTags.OptionRadio, true)
+            .get(1)
+            .assertIsSelected()
+    }
+
+    /**
+     * Checks if the "High" option is checked.
+     */
+    fun highIsSelected() {
+        composeContentTestRule
+            .onAllNodesWithTag(DialogTags.OptionRadio, true)
+            .get(2)
+            .assertIsSelected()
+    }
+}

--- a/app/src/androidTest/java/com/chesire/nekome/robots/settings/ImageQualityRobot.kt
+++ b/app/src/androidTest/java/com/chesire/nekome/robots/settings/ImageQualityRobot.kt
@@ -12,7 +12,6 @@ import com.chesire.nekome.helpers.getResource
 import com.chesire.nekome.robots.DialogResultsRobot
 import com.chesire.nekome.robots.DialogRobot
 
-
 class ImageQualityRobot(
     private val composeContentTestRule: ComposeContentTestRule
 ) : DialogRobot(composeContentTestRule) {

--- a/core/preferences/src/main/java/com/chesire/nekome/core/preferences/SeriesPreferences.kt
+++ b/core/preferences/src/main/java/com/chesire/nekome/core/preferences/SeriesPreferences.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.chesire.nekome.core.flags.UserSeriesStatus
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.SortOption
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -30,6 +31,7 @@ class SeriesPreferences @Inject constructor(
     private val rateOnCompletionKey = booleanPreferencesKey("preference.rateOnCompletion")
     private val sortPreferenceKey = intPreferencesKey("preference.sort")
     private val filterPreferenceKey = stringPreferencesKey("preference.filter")
+    private val imageQualityKey = intPreferencesKey("preference.imageQuality")
     private val filterAdapter by lazy {
         Moshi.Builder()
             .build()
@@ -74,6 +76,13 @@ class SeriesPreferences @Inject constructor(
     }
 
     /**
+     * Returns a [Flow] of the image quality value.
+     */
+    val imageQuality: Flow<ImageQuality> = context.dataStore.data.map { preferences ->
+        ImageQuality.forIndex(preferences[imageQualityKey] ?: ImageQuality.Low.index)
+    }
+
+    /**
      * Update the [sort] value with a new [SortOption].
      */
     suspend fun updateSort(value: SortOption) {
@@ -97,6 +106,15 @@ class SeriesPreferences @Inject constructor(
     suspend fun updateRateSeriesOnCompletion(value: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[rateOnCompletionKey] = value
+        }
+    }
+
+    /**
+     * Update the [imageQuality] value with new data.
+     */
+    suspend fun updateImageQuality(value: ImageQuality) {
+        context.dataStore.edit { preferences ->
+            preferences[imageQualityKey] = value.index
         }
     }
 }

--- a/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/ImageQuality.kt
+++ b/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/ImageQuality.kt
@@ -1,0 +1,21 @@
+package com.chesire.nekome.core.preferences.flags
+
+import androidx.annotation.StringRes
+import com.chesire.nekome.core.preferences.R
+
+/**
+ * Options available for the quality of the images.
+ */
+enum class ImageQuality(val index: Int, @StringRes val stringId: Int) {
+    Low(0, R.string.image_quality_low),
+    Medium(1, R.string.image_quality_medium),
+    High(2, R.string.image_quality_high);
+
+    companion object {
+
+        /**
+         * Get [ImageQuality] for its given [index].
+         */
+        fun forIndex(index: Int): ImageQuality = values().find { it.index == index } ?: Low
+    }
+}

--- a/core/preferences/src/test/java/com/chesire/nekome/core/preferences/flags/ImageQualityTests.kt
+++ b/core/preferences/src/test/java/com/chesire/nekome/core/preferences/flags/ImageQualityTests.kt
@@ -1,0 +1,31 @@
+package com.chesire.nekome.core.preferences.flags
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImageQualityTests {
+
+    @Test
+    fun `forIndex ImageQuality#Low returns expected value`() {
+        assertEquals(
+            ImageQuality.Low,
+            ImageQuality.forIndex(0)
+        )
+    }
+
+    @Test
+    fun `forIndex ImageQuality#Medium returns expected value`() {
+        assertEquals(
+            ImageQuality.Medium,
+            ImageQuality.forIndex(1)
+        )
+    }
+
+    @Test
+    fun `forIndex ImageQuality#High returns expected value`() {
+        assertEquals(
+            ImageQuality.High,
+            ImageQuality.forIndex(2)
+        )
+    }
+}

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -113,6 +113,8 @@
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
     <string name="settings_default_series_status_title">デフォルトのシリーズ状況</string>
     <string name="settings_default_series_status_summary">新しく追跡されたシリーズが開始されるステータス</string>
+    <string name="settings_image_quality_title">画質</string>
+    <string name="settings_image_quality_summary">アプリで表示する画像の品質</string>
     <string name="settings_default_home_title">デフォルトのホーム画面</string>
     <string name="settings_default_home_summary">アニメ／マンガから選択</string>
     <string name="settings_rate_on_completion_title">完了時にシリーズを評価</string>

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -44,6 +44,10 @@
     <string name="filter_by_dropped">ドロップ</string>
     <string name="filter_by_planned">予定</string>
 
+    <string name="image_quality_low">低い</string>
+    <string name="image_quality_medium">中くらい</string>
+    <string name="image_quality_high">高い</string>
+
     <string name="series_list_length">%s / %s</string>
     <string name="series_list_plus_one">+1</string>
     <string name="series_list_date_range">%s - %s</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="settings_github_url">https://github.com/Chesire/Nekome</string>
     <string name="settings_default_series_status_title">Default Series Status</string>
     <string name="settings_default_series_status_summary">Status a newly tracked series will start in</string>
+    <string name="settings_image_quality_title">Image Quality</string>
+    <string name="settings_image_quality_summary">Quality of images to display in the app</string>
     <string name="settings_default_home_title">Default Home Screen</string>
     <string name="settings_default_home_summary">Choose between Anime/Manga</string>
     <string name="settings_rate_on_completion_title">Rate series when completing</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -44,6 +44,10 @@
     <string name="filter_by_dropped">Dropped</string>
     <string name="filter_by_planned">Planned</string>
 
+    <string name="image_quality_low">Low</string>
+    <string name="image_quality_medium">Medium</string>
+    <string name="image_quality_high">High</string>
+
     <string name="series_list_length">%s / %s</string>
     <string name="series_list_plus_one">+1</string>
     <string name="series_list_date_range">%s - %s</string>

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/DomainMapper.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/DomainMapper.kt
@@ -1,10 +1,16 @@
 package com.chesire.nekome.app.series.collection.ui
 
 import com.chesire.nekome.core.models.ImageModel
+import com.chesire.nekome.core.preferences.SeriesPreferences
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.datasource.series.SeriesDomain
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
-class DomainMapper @Inject constructor() {
+class DomainMapper @Inject constructor(
+    private val seriesPreferences: SeriesPreferences
+) {
 
     fun toSeries(models: List<SeriesDomain>): List<Series> {
         return models.map { series ->
@@ -23,8 +29,18 @@ class DomainMapper @Inject constructor() {
         }
     }
 
-    private fun choosePosterImageUrl(imageModel: ImageModel): String =
-        imageModel.smallest?.url ?: ""
+    private fun choosePosterImageUrl(imageModel: ImageModel): String {
+        val imageQuality = runBlocking {
+            // Not sure this is the best, but not sure how to get the value otherwise
+            seriesPreferences.imageQuality.first()
+        }
+
+        return when (imageQuality) {
+            ImageQuality.Low -> imageModel.smallest?.url
+            ImageQuality.Medium -> imageModel.middlest?.url
+            ImageQuality.High -> imageModel.largest?.url
+        } ?: ""
+    }
 
     private fun buildProgress(progress: Int, totalLength: Int): String {
         val maxLengthString = if (totalLength == 0) "-" else totalLength

--- a/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/DomainMapperTest.kt
+++ b/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/DomainMapperTest.kt
@@ -5,13 +5,23 @@ import com.chesire.nekome.core.flags.SeriesType
 import com.chesire.nekome.core.flags.Subtype
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.ImageModel
+import com.chesire.nekome.core.preferences.SeriesPreferences
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.datasource.series.SeriesDomain
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
 class DomainMapperTest {
 
+    private val seriesPreferences = mockk<SeriesPreferences> {
+        every { imageQuality } returns flowOf(ImageQuality.Medium)
+    }
     private lateinit var mapper: DomainMapper
     private val initialDomain = SeriesDomain(
         id = 0,
@@ -53,17 +63,19 @@ class DomainMapperTest {
 
     @Before
     fun setup() {
-        mapper = DomainMapper()
+        clearAllMocks()
+
+        mapper = DomainMapper(seriesPreferences)
     }
 
     @Test
-    fun `When toSeries, Then list of Series item is returned`() {
+    fun `When toSeries, Then list of Series item is returned`() = runTest {
         val input = listOf(initialDomain)
         val expected = listOf(
             Series(
                 userId = 1,
                 title = "Anime series",
-                posterImageUrl = "tiny",
+                posterImageUrl = "medium",
                 subtype = Subtype.Movie.name,
                 progress = "1 / 1",
                 startDate = "abc",
@@ -80,13 +92,13 @@ class DomainMapperTest {
     }
 
     @Test
-    fun `Given no known series length, When toSeries, Then max length is set to -`() {
+    fun `Given no known series length, When toSeries, Then max length is set to -`() = runTest {
         val input = listOf(initialDomain.copy(totalLength = 0))
         val expected = listOf(
             Series(
                 userId = 1,
                 title = "Anime series",
-                posterImageUrl = "tiny",
+                posterImageUrl = "medium",
                 subtype = Subtype.Movie.name,
                 progress = "1 / -",
                 startDate = "abc",
@@ -103,13 +115,13 @@ class DomainMapperTest {
     }
 
     @Test
-    fun `Given user can +1 progress, When toSeries, Then shouldPlusOne is true`() {
+    fun `Given user can +1 progress, When toSeries, Then shouldPlusOne is true`() = runTest {
         val input = listOf(initialDomain.copy(totalLength = 15))
         val expected = listOf(
             Series(
                 userId = 1,
                 title = "Anime series",
-                posterImageUrl = "tiny",
+                posterImageUrl = "medium",
                 subtype = Subtype.Movie.name,
                 progress = "1 / 15",
                 startDate = "abc",

--- a/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/DomainMapperTest.kt
+++ b/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/DomainMapperTest.kt
@@ -19,9 +19,7 @@ import org.junit.Test
 
 class DomainMapperTest {
 
-    private val seriesPreferences = mockk<SeriesPreferences> {
-        every { imageQuality } returns flowOf(ImageQuality.Medium)
-    }
+    private val seriesPreferences = mockk<SeriesPreferences>()
     private lateinit var mapper: DomainMapper
     private val initialDomain = SeriesDomain(
         id = 0,
@@ -65,6 +63,7 @@ class DomainMapperTest {
     fun setup() {
         clearAllMocks()
 
+        every { seriesPreferences.imageQuality } returns flowOf(ImageQuality.Medium)
         mapper = DomainMapper(seriesPreferences)
     }
 

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/core/RetrievePreferencesUseCase.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/core/RetrievePreferencesUseCase.kt
@@ -4,6 +4,7 @@ import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.ApplicationPreferences
 import com.chesire.nekome.core.preferences.SeriesPreferences
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -23,10 +24,13 @@ class RetrievePreferencesUseCase @Inject constructor(
                 theme = Theme.System,
                 defaultHomeScreen = HomeScreenOptions.Anime,
                 defaultSeriesStatus = UserSeriesStatus.Current,
-                shouldRateSeries = false
+                shouldRateSeries = false,
+                imageQuality = ImageQuality.Low
             )
         ).combine(seriesPref.rateSeriesOnCompletion) { model, rateSeriesOnCompletion ->
             model.copy(shouldRateSeries = rateSeriesOnCompletion)
+        }.combine(seriesPref.imageQuality) { model, imageQuality ->
+            model.copy(imageQuality = imageQuality)
         }.combine(applicationPref.theme) { model, theme ->
             model.copy(theme = theme)
         }.combine(applicationPref.defaultHomeScreen) { model, homeScreen ->
@@ -41,5 +45,6 @@ data class PreferenceModel(
     val theme: Theme,
     val defaultHomeScreen: HomeScreenOptions,
     val defaultSeriesStatus: UserSeriesStatus,
-    val shouldRateSeries: Boolean
+    val shouldRateSeries: Boolean,
+    val imageQuality: ImageQuality
 )

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/core/UpdateImageQualityUseCase.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/core/UpdateImageQualityUseCase.kt
@@ -1,0 +1,14 @@
+package com.chesire.nekome.app.settings.config.core
+
+import com.chesire.nekome.core.preferences.SeriesPreferences
+import com.chesire.nekome.core.preferences.flags.ImageQuality
+import javax.inject.Inject
+import timber.log.Timber
+
+class UpdateImageQualityUseCase @Inject constructor(private val pref: SeriesPreferences) {
+
+    suspend operator fun invoke(newImageQuality: ImageQuality) {
+        Timber.i("Updating image quality to [$newImageQuality]")
+        pref.updateImageQuality(newImageQuality)
+    }
+}

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigScreen.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigScreen.kt
@@ -47,6 +47,7 @@ import com.chesire.nekome.core.compose.composables.NekomeDialog
 import com.chesire.nekome.core.compose.theme.NekomeTheme
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 
 @Composable
@@ -68,6 +69,8 @@ fun ConfigScreen(
         onDefaultSeriesStatusResult = {
             viewModel.execute(ViewAction.OnDefaultSeriesStatusChanged(it))
         },
+        onImageQualityClicked = { viewModel.execute(ViewAction.OnImageQualityClicked) },
+        onImageQualityResult = { viewModel.execute(ViewAction.OnImageQualityChanged(it)) },
         onRateSeriesClicked = { viewModel.execute(ViewAction.OnRateSeriesChanged(it)) },
         onLicensesLinkClicked = { navigateToOssScreen() }
     )
@@ -89,6 +92,8 @@ private fun Render(
     onDefaultHomeScreenResult: (HomeScreenOptions?) -> Unit,
     onDefaultSeriesStatusClicked: () -> Unit,
     onDefaultSeriesStatusResult: (UserSeriesStatus?) -> Unit,
+    onImageQualityClicked: () -> Unit,
+    onImageQualityResult: (ImageQuality?) -> Unit,
     onRateSeriesClicked: (Boolean) -> Unit,
     onLicensesLinkClicked: () -> Unit
 ) {
@@ -110,6 +115,7 @@ private fun Render(
 
             SeriesHeading()
             DefaultSeriesStatusPreference(onDefaultSeriesStatusClicked)
+            ImageQualityPreference(onImageQualityClicked)
             RateSeriesPreference(state.value.rateSeriesValue, onRateSeriesClicked)
 
             AboutHeading()
@@ -167,6 +173,20 @@ private fun Render(
                 .associateWith { stringResource(id = it.stringId) }
                 .toList(),
             onResult = onDefaultSeriesStatusResult
+        )
+    }
+
+    if (state.value.showImageQualityDialog) {
+        NekomeDialog(
+            title = R.string.settings_image_quality_title,
+            confirmButton = R.string.ok,
+            cancelButton = R.string.cancel,
+            currentValue = state.value.imageQualityValue,
+            allValues = ImageQuality
+                .values()
+                .associateWith { stringResource(id = it.stringId) }
+                .toList(),
+            onResult = onImageQualityResult
         )
     }
 }
@@ -250,6 +270,15 @@ private fun DefaultSeriesStatusPreference(onDefaultSeriesStatusClicked: () -> Un
         title = stringResource(id = R.string.settings_default_series_status_title),
         summary = stringResource(id = R.string.settings_default_series_status_summary),
         onClick = onDefaultSeriesStatusClicked
+    )
+}
+
+@Composable
+private fun ImageQualityPreference(onImageQualityClicked: () -> Unit) {
+    PreferenceSection(
+        title = stringResource(id = R.string.settings_image_quality_title),
+        summary = stringResource(id = R.string.settings_image_quality_summary),
+        onClick = onImageQualityClicked
     )
 }
 
@@ -370,6 +399,8 @@ private fun Preview() {
         showDefaultHomeDialog = false,
         defaultSeriesStatusValue = UserSeriesStatus.Current,
         showDefaultSeriesStatusDialog = false,
+        imageQualityValue = ImageQuality.Low,
+        showImageQualityDialog = false,
         rateSeriesValue = false
     )
     NekomeTheme(isDarkTheme = true) {
@@ -386,6 +417,8 @@ private fun Preview() {
             onDefaultHomeScreenResult = { /**/ },
             onDefaultSeriesStatusClicked = { /**/ },
             onDefaultSeriesStatusResult = { /**/ },
+            onImageQualityClicked = { /**/ },
+            onImageQualityResult = { /**/ },
             onRateSeriesClicked = { /**/ },
             onLicensesLinkClicked = { /**/ }
         )

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModel.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModel.kt
@@ -7,10 +7,12 @@ import com.chesire.nekome.app.settings.config.core.RetrievePreferencesUseCase
 import com.chesire.nekome.app.settings.config.core.RetrieveUserUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateDefaultHomeScreenUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateDefaultSeriesStateUseCase
+import com.chesire.nekome.app.settings.config.core.UpdateImageQualityUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateRateSeriesUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateThemeUseCase
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 import com.chesire.nekome.datasource.user.User
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,6 +31,7 @@ class ConfigViewModel @Inject constructor(
     private val updateTheme: UpdateThemeUseCase,
     private val updateDefaultHomeScreen: UpdateDefaultHomeScreenUseCase,
     private val updateDefaultSeriesState: UpdateDefaultSeriesStateUseCase,
+    private val updateImageQuality: UpdateImageQualityUseCase,
     private val logoutExecutor: LogoutExecutor
 ) : ViewModel() {
 
@@ -58,7 +61,8 @@ class ConfigViewModel @Inject constructor(
                         themeValue = prefModel.theme,
                         defaultHomeValue = prefModel.defaultHomeScreen,
                         defaultSeriesStatusValue = prefModel.defaultSeriesStatus,
-                        rateSeriesValue = prefModel.shouldRateSeries
+                        rateSeriesValue = prefModel.shouldRateSeries,
+                        imageQualityValue = prefModel.imageQuality
                     )
                 }
             }
@@ -70,8 +74,10 @@ class ConfigViewModel @Inject constructor(
             ViewAction.OnLogoutClicked -> handleOnLogoutClicked()
             is ViewAction.OnLogoutResult -> handleOnLogoutResult(action.logout)
             ViewAction.ConsumeExecuteLogout -> handleConsumeExecuteLogout()
+
             ViewAction.OnThemeClicked -> handleOnThemeClicked()
             is ViewAction.OnThemeChanged -> handleOnThemeChanged(action.newTheme)
+
             ViewAction.OnDefaultHomeScreenClicked -> handleOnDefaultHomeScreenClicked()
             is ViewAction.OnDefaultHomeScreenChanged ->
                 handleOnDefaultHomeScreenChanged(action.newHomeScreen)
@@ -79,6 +85,10 @@ class ConfigViewModel @Inject constructor(
             ViewAction.OnDefaultSeriesStatusClicked -> handleOnDefaultSeriesStatusClicked()
             is ViewAction.OnDefaultSeriesStatusChanged ->
                 handleOnDefaultSeriesStatusChanged(action.newDefaultSeriesStatus)
+
+            ViewAction.OnImageQualityClicked -> handleOnImageQualityClicked()
+            is ViewAction.OnImageQualityChanged ->
+                handleOnImageQualityChanged(action.newImageQuality)
 
             is ViewAction.OnRateSeriesChanged -> handleOnRateSeriesChanged(action.newValue)
         }
@@ -137,6 +147,19 @@ class ConfigViewModel @Inject constructor(
         if (newSeriesStatus != null) {
             viewModelScope.launch {
                 updateDefaultSeriesState(newSeriesStatus)
+            }
+        }
+    }
+
+    private fun handleOnImageQualityClicked() {
+        state = state.copy(showImageQualityDialog = true)
+    }
+
+    private fun handleOnImageQualityChanged(newImageQuality: ImageQuality?) {
+        state = state.copy(showImageQualityDialog = false)
+        if (newImageQuality != null) {
+            viewModelScope.launch {
+                updateImageQuality(newImageQuality)
             }
         }
     }

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/UIState.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/UIState.kt
@@ -2,6 +2,7 @@ package com.chesire.nekome.app.settings.config.ui
 
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 
 data class UIState(
@@ -14,6 +15,8 @@ data class UIState(
     val showDefaultHomeDialog: Boolean,
     val defaultSeriesStatusValue: UserSeriesStatus,
     val showDefaultSeriesStatusDialog: Boolean,
+    val imageQualityValue: ImageQuality,
+    val showImageQualityDialog: Boolean,
     val rateSeriesValue: Boolean
 ) {
     companion object {
@@ -27,6 +30,8 @@ data class UIState(
             showDefaultHomeDialog = false,
             defaultSeriesStatusValue = UserSeriesStatus.Current,
             showDefaultSeriesStatusDialog = false,
+            imageQualityValue = ImageQuality.Low,
+            showImageQualityDialog = false,
             rateSeriesValue = false
         )
     }

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ViewAction.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ViewAction.kt
@@ -2,6 +2,7 @@ package com.chesire.nekome.app.settings.config.ui
 
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 
 sealed interface ViewAction {
@@ -23,6 +24,9 @@ sealed interface ViewAction {
     data class OnDefaultSeriesStatusChanged(
         val newDefaultSeriesStatus: UserSeriesStatus?
     ) : ViewAction
+
+    object OnImageQualityClicked : ViewAction
+    data class OnImageQualityChanged(val newImageQuality: ImageQuality?) : ViewAction
 
     data class OnRateSeriesChanged(val newValue: Boolean) : ViewAction
 }

--- a/features/settings/src/test/java/com/chesire/nekome/app/settings/config/core/RetrievePreferencesUseCaseTest.kt
+++ b/features/settings/src/test/java/com/chesire/nekome/app/settings/config/core/RetrievePreferencesUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.preferences.ApplicationPreferences
 import com.chesire.nekome.core.preferences.SeriesPreferences
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -34,10 +35,11 @@ class RetrievePreferencesUseCaseTest {
             theme = Theme.Light,
             defaultHomeScreen = HomeScreenOptions.Manga,
             defaultSeriesStatus = UserSeriesStatus.Dropped,
-            shouldRateSeries = true
-
+            shouldRateSeries = true,
+            imageQuality = ImageQuality.High
         )
         coEvery { seriesPref.rateSeriesOnCompletion } returns flowOf(expected.shouldRateSeries)
+        coEvery { seriesPref.imageQuality } returns flowOf(expected.imageQuality)
         coEvery { applicationPref.theme } returns flowOf(expected.theme)
         coEvery { applicationPref.defaultHomeScreen } returns flowOf(expected.defaultHomeScreen)
         coEvery { applicationPref.defaultSeriesState } returns flowOf(expected.defaultSeriesStatus)

--- a/features/settings/src/test/java/com/chesire/nekome/app/settings/config/core/UpdateImageQualityUseCaseTest.kt
+++ b/features/settings/src/test/java/com/chesire/nekome/app/settings/config/core/UpdateImageQualityUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.chesire.nekome.app.settings.config.core
+
+import com.chesire.nekome.core.preferences.SeriesPreferences
+import com.chesire.nekome.core.preferences.flags.ImageQuality
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class UpdateImageQualityUseCaseTest {
+
+    private val pref = mockk<SeriesPreferences>()
+    private lateinit var updateImageQuality: UpdateImageQualityUseCase
+
+    @Before
+    fun setup() {
+        clearAllMocks()
+
+        updateImageQuality = UpdateImageQualityUseCase(pref)
+    }
+
+    @Test
+    fun `When invoking, update pref with new value`() = runTest {
+        coEvery { pref.updateImageQuality(any()) } just runs
+
+        updateImageQuality(ImageQuality.Medium)
+
+        coEvery { pref.updateImageQuality(ImageQuality.Medium) }
+    }
+}

--- a/features/settings/src/test/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModelTest.kt
+++ b/features/settings/src/test/java/com/chesire/nekome/app/settings/config/ui/ConfigViewModelTest.kt
@@ -8,12 +8,14 @@ import com.chesire.nekome.app.settings.config.core.RetrievePreferencesUseCase
 import com.chesire.nekome.app.settings.config.core.RetrieveUserUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateDefaultHomeScreenUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateDefaultSeriesStateUseCase
+import com.chesire.nekome.app.settings.config.core.UpdateImageQualityUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateRateSeriesUseCase
 import com.chesire.nekome.app.settings.config.core.UpdateThemeUseCase
 import com.chesire.nekome.core.flags.Service
 import com.chesire.nekome.core.flags.UserSeriesStatus
 import com.chesire.nekome.core.models.ImageModel
 import com.chesire.nekome.core.preferences.flags.HomeScreenOptions
+import com.chesire.nekome.core.preferences.flags.ImageQuality
 import com.chesire.nekome.core.preferences.flags.Theme
 import com.chesire.nekome.datasource.user.User
 import com.chesire.nekome.datasource.user.UserDomain
@@ -41,6 +43,7 @@ class ConfigViewModelTest {
     private val updateTheme = mockk<UpdateThemeUseCase>(relaxed = true)
     private val updateDefaultHomeScreen = mockk<UpdateDefaultHomeScreenUseCase>(relaxed = true)
     private val updateDefaultSeriesState = mockk<UpdateDefaultSeriesStateUseCase>(relaxed = true)
+    private val updateImageQualityUseCase = mockk<UpdateImageQualityUseCase>(relaxed = true)
     private val logoutExecutor = mockk<LogoutExecutor>(relaxed = true)
     private lateinit var viewModel: ConfigViewModel
 
@@ -56,7 +59,8 @@ class ConfigViewModelTest {
                 theme = Theme.Dark,
                 defaultHomeScreen = HomeScreenOptions.Anime,
                 defaultSeriesStatus = UserSeriesStatus.Current,
-                shouldRateSeries = false
+                shouldRateSeries = false,
+                imageQuality = ImageQuality.Low
             )
         )
         every {
@@ -80,6 +84,7 @@ class ConfigViewModelTest {
             updateTheme,
             updateDefaultHomeScreen,
             updateDefaultSeriesState,
+            updateImageQualityUseCase,
             logoutExecutor
         )
     }
@@ -99,6 +104,8 @@ class ConfigViewModelTest {
             showDefaultHomeDialog = false,
             defaultSeriesStatusValue = UserSeriesStatus.Current,
             showDefaultSeriesStatusDialog = false,
+            imageQualityValue = ImageQuality.Low,
+            showImageQualityDialog = false,
             rateSeriesValue = false
         )
 
@@ -168,5 +175,26 @@ class ConfigViewModelTest {
         viewModel.execute(ViewAction.OnDefaultSeriesStatusChanged(UserSeriesStatus.Dropped))
 
         coVerify { updateDefaultSeriesState(UserSeriesStatus.Dropped) }
+    }
+
+    @Test
+    fun `When execute#OnImageQualityClicked, Then dialog is shown`() = runTest {
+        viewModel.execute(ViewAction.OnImageQualityClicked)
+
+        assertTrue(viewModel.uiState.value.showImageQualityDialog)
+    }
+
+    @Test
+    fun `When execute#OnImageQualityChanged, Then dialog is hidden`() = runTest {
+        viewModel.execute(ViewAction.OnImageQualityChanged(ImageQuality.Medium))
+
+        assertFalse(viewModel.uiState.value.showImageQualityDialog)
+    }
+
+    @Test
+    fun `When execute#OnImageQualityChanged, Then value is updated in use case`() = runTest {
+        viewModel.execute(ViewAction.OnImageQualityChanged(ImageQuality.High))
+
+        coVerify { updateImageQualityUseCase(ImageQuality.High) }
     }
 }

--- a/libraries/core/src/main/java/com/chesire/nekome/core/models/ImageModel.kt
+++ b/libraries/core/src/main/java/com/chesire/nekome/core/models/ImageModel.kt
@@ -17,32 +17,41 @@ data class ImageModel(
     val medium: ImageData,
     val large: ImageData
 ) : Parcelable {
+
     /**
-     * The largest ImageData that contains a URL, returns null if no URL is valid.
+     * The largest [ImageData] that contains a URL, returns null if no URL is valid.
      */
     val largest: ImageData?
-        get() {
-            return when {
-                large.url.isNotEmpty() -> large
-                medium.url.isNotEmpty() -> medium
-                small.url.isNotEmpty() -> small
-                tiny.url.isNotEmpty() -> tiny
-                else -> null
-            }
+        get() = when {
+            large.url.isNotEmpty() -> large
+            medium.url.isNotEmpty() -> medium
+            small.url.isNotEmpty() -> small
+            tiny.url.isNotEmpty() -> tiny
+            else -> null
         }
 
     /**
-     * The smallest ImageData that contains a URL, returns null if no URL is valid.
+     * The [ImageData] that sits closest to the middle, returns null if no URL is valid.
+     */
+    val middlest: ImageData?
+        get() = when {
+            medium.url.isNotEmpty() -> medium
+            small.url.isNotEmpty() -> small
+            large.url.isNotEmpty() -> large
+            tiny.url.isNotEmpty() -> tiny
+            else -> null
+        }
+
+    /**
+     * The smallest [ImageData] that contains a URL, returns null if no URL is valid.
      */
     val smallest: ImageData?
-        get() {
-            return when {
-                tiny.url.isNotEmpty() -> tiny
-                small.url.isNotEmpty() -> small
-                medium.url.isNotEmpty() -> medium
-                large.url.isNotEmpty() -> large
-                else -> null
-            }
+        get() = when {
+            tiny.url.isNotEmpty() -> tiny
+            small.url.isNotEmpty() -> small
+            medium.url.isNotEmpty() -> medium
+            large.url.isNotEmpty() -> large
+            else -> null
         }
 
     companion object {

--- a/libraries/core/src/test/java/com/chesire/nekome/core/models/ImageModelTests.kt
+++ b/libraries/core/src/test/java/com/chesire/nekome/core/models/ImageModelTests.kt
@@ -34,6 +34,11 @@ class ImageModelTests {
     }
 
     @Test
+    fun `middlest returns middle value for inputs`() {
+        assertEquals(expected, ImageModel(other, other, expected, other).middlest)
+    }
+
+    @Test
     fun `smallest returns tiny when smallest available model`() {
         assertEquals(expected, ImageModel(expected, other, other, other).smallest)
     }


### PR DESCRIPTION
Add an option to change the image quality for various images in the app.
By default we have been using a low quality image, but for higher quality displays "medium" or "high" will look much nicer.