### PR TITLE
fix: r8 release failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.chesire.nekome"
         minSdk = 21
         targetSdk = libs.versions.sdk.get().toInt()
-        versionCode = 23100818 // Date of build formatted as 'yyMMddHH'
-        versionName = "2.1.0"
+        versionCode = 23101020 // Date of build formatted as 'yyMMddHH'
+        versionName = "2.1.1"
         testInstrumentationRunner = "com.chesire.nekome.TestRunner"
         resourceConfigurations += listOf("en", "ja")
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,12 @@
 # https://developer.android.com/guide/navigation/navigation-pass-data#use_keepnames_rules
 -keepnames class * extends android.os.Parcelable
 -keepnames class * extends java.io.Serializable
+
+ # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/fastlane/metadata/android/en-GB/changelogs/23101020.txt
+++ b/fastlane/metadata/android/en-GB/changelogs/23101020.txt
@@ -1,0 +1,1 @@
+* Fix issue with R8 causing api failures

--- a/fastlane/metadata/android/en-US/changelogs/23101020.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23101020.txt
@@ -1,0 +1,1 @@
+* Fix issue with R8 causing api failures


### PR DESCRIPTION
R8 is causing failures for api calls, fix by adding the correct proguard settings.