### PR TITLE
fix: crash when navigating to series with slash in name

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.chesire.nekome"
         minSdk = 21
         targetSdk = libs.versions.sdk.get().toInt()
-        versionCode = 24012009 // Date of build formatted as 'yyMMddHH'
-        versionName = "2.2.1"
+        versionCode = 24012317 // Date of build formatted as 'yyMMddHH'
+        versionName = "2.2.2"
         testInstrumentationRunner = "com.chesire.nekome.TestRunner"
         resourceConfigurations += listOf("en", "ja")
     }

--- a/app/src/main/java/com/chesire/nekome/ui/Routes.kt
+++ b/app/src/main/java/com/chesire/nekome/ui/Routes.kt
@@ -43,8 +43,8 @@ fun NavGraphBuilder.addSeriesRoutes(navController: NavHostController) {
         arguments = Screen.Anime.args
     ) {
         CollectionScreen(
-            navigateToItem = { seriesId, seriesTitle ->
-                navController.navigate("${Screen.Item.destination}/$seriesId/$seriesTitle")
+            navigateToItem = { seriesId ->
+                navController.navigate("${Screen.Item.destination}/$seriesId")
             },
             navigateToSearch = {
                 navController.navigate(Screen.Search.route)
@@ -57,8 +57,8 @@ fun NavGraphBuilder.addSeriesRoutes(navController: NavHostController) {
         arguments = Screen.Manga.args
     ) {
         CollectionScreen(
-            navigateToItem = { seriesId, seriesTitle ->
-                navController.navigate("${Screen.Item.destination}/$seriesId/$seriesTitle")
+            navigateToItem = { seriesId ->
+                navController.navigate("${Screen.Item.destination}/$seriesId")
             },
             navigateToSearch = {
                 navController.navigate(Screen.Search.route)

--- a/app/src/main/java/com/chesire/nekome/ui/Screen.kt
+++ b/app/src/main/java/com/chesire/nekome/ui/Screen.kt
@@ -78,12 +78,11 @@ sealed class Screen {
     }
 
     data object Item : Screen() {
-        override val route = "item/{seriesId}/{seriesTitle}"
+        override val route = "item/{seriesId}"
         const val destination = "item"
 
         override val args = listOf(
             navArgument("seriesId") { type = NavType.IntType },
-            navArgument("seriesTitle") { type = NavType.StringType }
         )
     }
 

--- a/app/src/main/java/com/chesire/nekome/ui/Screen.kt
+++ b/app/src/main/java/com/chesire/nekome/ui/Screen.kt
@@ -82,7 +82,7 @@ sealed class Screen {
         const val destination = "item"
 
         override val args = listOf(
-            navArgument("seriesId") { type = NavType.IntType },
+            navArgument("seriesId") { type = NavType.IntType }
         )
     }
 

--- a/fastlane/metadata/android/en-GB/changelogs/24012317.txt
+++ b/fastlane/metadata/android/en-GB/changelogs/24012317.txt
@@ -1,0 +1,1 @@
+* Fix crash when navigating to series detail view, if series has a / in the name

--- a/fastlane/metadata/android/en-US/changelogs/24012317.txt
+++ b/fastlane/metadata/android/en-US/changelogs/24012317.txt
@@ -1,0 +1,1 @@
+* Fix crash when navigating to series detail view, if series has a / in the name

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
@@ -82,14 +82,14 @@ import com.chesire.nekome.resources.StringResource
 @Composable
 fun CollectionScreen(
     viewModel: CollectionViewModel = hiltViewModel(),
-    navigateToItem: (Int, String) -> Unit,
+    navigateToItem: (Int) -> Unit,
     navigateToSearch: () -> Unit
 ) {
     val state = viewModel.uiState.collectAsState()
 
     state.value.seriesDetails?.let {
         LaunchedEffect(it.show) {
-            navigateToItem(it.seriesId, it.seriesTitle)
+            navigateToItem(it.seriesId)
             viewModel.execute(ViewAction.SeriesNavigationObserved)
         }
     }

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModel.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModel.kt
@@ -117,8 +117,7 @@ class CollectionViewModel @Inject constructor(
         state = state.copy(
             seriesDetails = SeriesDetails(
                 show = true,
-                seriesId = series.userId,
-                seriesTitle = series.title
+                seriesId = series.userId
             )
         )
     }

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/UIState.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/UIState.kt
@@ -68,8 +68,7 @@ data class SnackbarData(
 
 data class SeriesDetails(
     val show: Boolean,
-    val seriesId: Int,
-    val seriesTitle: String
+    val seriesId: Int
 )
 
 data class Sort(

--- a/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModelTest.kt
+++ b/features/series/src/test/java/com/chesire/nekome/app/series/collection/ui/CollectionViewModelTest.kt
@@ -143,8 +143,7 @@ class CollectionViewModelTest {
         assertEquals(
             SeriesDetails(
                 show = true,
-                seriesId = model.userId,
-                seriesTitle = model.title
+                seriesId = model.userId
             ),
             viewModel.uiState.value.seriesDetails
         )
@@ -158,8 +157,7 @@ class CollectionViewModelTest {
         assertEquals(
             SeriesDetails(
                 show = true,
-                seriesId = model.userId,
-                seriesTitle = model.title
+                seriesId = model.userId
             ),
             viewModel.uiState.value.seriesDetails
         )


### PR DESCRIPTION
Remove passing the series name through to the Item screen as it is never used. This stops the crash occurring as titles such as Fate/Stay night would cause an exception.

Fixes #1162 