### PR TITLE
chore: remove unusued navigation args plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.google.dagger.hilt.android)
     alias(libs.plugins.google.devtools.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.androidx.navigation.safeargs)
     alias(libs.plugins.aboutlibraries)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.aboutlibraries) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.androidx.navigation.safeargs) apply false
     alias(libs.plugins.google.dagger.hilt.android) apply false
     alias(libs.plugins.google.devtools.ksp) apply false
     alias(libs.plugins.kotlin.android) apply false

--- a/features/login/build.gradle.kts
+++ b/features/login/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.google.dagger.hilt.android)
     alias(libs.plugins.google.devtools.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/features/search/build.gradle.kts
+++ b/features/search/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.google.dagger.hilt.android)
     alias(libs.plugins.google.devtools.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/features/series/build.gradle.kts
+++ b/features/series/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.google.dagger.hilt.android)
     alias(libs.plugins.google.devtools.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/features/settings/build.gradle.kts
+++ b/features/settings/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.google.dagger.hilt.android)
     alias(libs.plugins.google.devtools.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,6 @@ timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
-androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 google-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 google-devtools-ksp = { id = "com.google.devtools.ksp", version = "1.9.20-1.0.14" }


### PR DESCRIPTION
This plugin hasn't been used since moving to compose navigation, and wasn't required anymore.

Closes #1163