### PR TITLE
WIP: feat: Dark theme for AMOLED screens

### DIFF
--- a/app/src/main/java/com/chesire/nekome/ui/MainActivity.kt
+++ b/app/src/main/java/com/chesire/nekome/ui/MainActivity.kt
@@ -24,12 +24,12 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val themeState = appSettings.theme.collectAsState(initial = Theme.System)
-            val (isDarkMode, isDynamicColor) = generateTheme(
+            val (theme, isDynamicColor) = generateTheme(
                 theme = themeState.value,
                 isSystemDarkMode = isSystemInDarkTheme()
             )
             NekomeTheme(
-                isDarkTheme = isDarkMode,
+                theme = theme.value,
                 isDynamicColor = isDynamicColor
             ) {
                 MainActivityScreen()
@@ -40,13 +40,15 @@ class MainActivity : ComponentActivity() {
     /**
      * Returns a [Pair] of (dark mode enabled) to (dynamic color enabled).
      */
-    private fun generateTheme(theme: Theme, isSystemDarkMode: Boolean): Pair<Boolean, Boolean> {
+    private fun generateTheme(theme: Theme, isSystemDarkMode: Boolean): Pair<Theme, Boolean> {
+        val systemTheme = if(isSystemDarkMode) Theme.Dark else Theme.Light
         return when (theme) {
-            Theme.System -> isSystemDarkMode to true
-            Theme.Dark -> true to false
-            Theme.Light -> false to false
-            Theme.DynamicDark -> true to true
-            Theme.DynamicLight -> false to true
+            Theme.System -> systemTheme to true
+            Theme.Dark -> Theme.Dark to false
+            Theme.Light -> Theme.Light to false
+            Theme.Black -> Theme.Black to false
+            Theme.DynamicDark -> Theme.DynamicDark to true
+            Theme.DynamicLight -> Theme.DynamicLight to true
         }
     }
 }

--- a/core/compose/src/main/java/com/chesire/nekome/core/compose/theme/Color.kt
+++ b/core/compose/src/main/java/com/chesire/nekome/core/compose/theme/Color.kt
@@ -55,3 +55,8 @@ val LightColorPalette = lightColorScheme(
     surfaceVariant = Color(0xFFdce4e9),
     onSurfaceVariant = Color(0xFF40484c)
 )
+
+val BlackColorPalette = DarkColorPalette.copy(
+    background = Color(0xFF000000),
+    surface = Color(0xFF000000)
+)

--- a/core/compose/src/main/java/com/chesire/nekome/core/compose/theme/Theme.kt
+++ b/core/compose/src/main/java/com/chesire/nekome/core/compose/theme/Theme.kt
@@ -10,19 +10,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
+/**
+ * Used to set the theme for a given composable, defaulting to the system theme
+ * @param theme an int preferably defined by the enum [Theme][com.chesire.nekome.core.preferences.flags.Theme]
+ * @param isDynamicColor a boolean that sets whether the given theme will be dynamic or not
+ * @param content a composable you want to set the given theme to
+ */
 @Composable
 fun NekomeTheme(
-    isDarkTheme: Boolean = isSystemInDarkTheme(),
+    theme: Int,
     isDynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val isSystemDarkTheme = isSystemInDarkTheme()
     val systemUiController = rememberSystemUiController()
 
     val dynamicColor = isDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val colorScheme = when {
-        dynamicColor && isDarkTheme -> dynamicDarkColorScheme(LocalContext.current)
-        dynamicColor && !isDarkTheme -> dynamicLightColorScheme(LocalContext.current)
-        isDarkTheme -> DarkColorPalette
+        dynamicColor && isSystemDarkTheme -> dynamicDarkColorScheme(LocalContext.current)
+        dynamicColor && !isSystemDarkTheme -> dynamicLightColorScheme(LocalContext.current)
+        theme == 1 -> LightColorPalette
+        theme == 2 -> DarkColorPalette
+        theme == 5 -> BlackColorPalette
         else -> LightColorPalette
     }
     systemUiController.apply {
@@ -32,7 +41,7 @@ fun NekomeTheme(
 
     Log.d(
         "Nekome",
-        "Is system in dark theme? [$isDarkTheme], is using dynamic color? [$isDynamicColor]"
+        "Is system in dark theme? [$isSystemDarkTheme], is using dynamic color? [$isDynamicColor]"
     )
 
     MaterialTheme(

--- a/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/Theme.kt
+++ b/core/preferences/src/main/java/com/chesire/nekome/core/preferences/flags/Theme.kt
@@ -12,7 +12,8 @@ enum class Theme(val value: Int, @StringRes val stringId: Int) {
     Dark(2, StringResource.settings_theme_dark),
     Light(1, StringResource.settings_theme_light),
     DynamicDark(3, StringResource.settings_theme_dynamic_dark),
-    DynamicLight(4, StringResource.settings_theme_dynamic_light);
+    DynamicLight(4, StringResource.settings_theme_dynamic_light),
+    Black(5, StringResource.settings_theme_black);
 
     companion object {
         /**

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -138,6 +138,7 @@
     <string name="settings_theme_dynamic_dark">ダイナミックダークテーマ</string>
     <string name="settings_theme_dynamic_light">ダイナミックライトテーマ</string>
 
+    <string name="settings_theme_black">ブラックテーマ</string>
     <string name="discover_trending_anime">流行中のアニメ</string>
     <string name="discover_trending_manga">流行中の漫画</string>
     <string name="discover_trending_track">トラック</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dynamic_dark">Dynamic Dark</string>
     <string name="settings_theme_dynamic_light">Dynamic Light</string>
+    <string name="settings_theme_black">Black</string>
 
     <string name="discover_trending_anime">Trending Anime</string>
     <string name="discover_trending_manga">Trending Manga</string>

--- a/features/login/src/main/java/com/chesire/nekome/app/login/credentials/ui/CredentialsScreen.kt
+++ b/features/login/src/main/java/com/chesire/nekome/app/login/credentials/ui/CredentialsScreen.kt
@@ -321,7 +321,7 @@ private fun Preview() {
         errorSnackbarMessage = null,
         navigateScreenEvent = null
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(initialValue = initialState, producer = { value = initialState }),
             { /**/ },

--- a/features/login/src/main/java/com/chesire/nekome/app/login/syncing/ui/SyncingScreen.kt
+++ b/features/login/src/main/java/com/chesire/nekome/app/login/syncing/ui/SyncingScreen.kt
@@ -104,7 +104,7 @@ private fun Preview() {
         avatar = "https://media.kitsu.io/users/avatars/294558/large.jpeg",
         finishedSyncing = null
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(initialValue = initialState, producer = { value = initialState })
         )

--- a/features/search/src/main/java/com/chesire/nekome/app/search/search/ui/SearchScreen.kt
+++ b/features/search/src/main/java/com/chesire/nekome/app/search/search/ui/SearchScreen.kt
@@ -343,7 +343,7 @@ private fun Preview() {
         resultModels = emptyList(),
         errorSnackbar = null
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(initialValue = initialState, producer = { value = initialState }),
             onInputTextChanged = { /**/ },
@@ -387,7 +387,7 @@ private fun PopulatedPreview() {
         ),
         errorSnackbar = null
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(initialValue = initialState, producer = { value = initialState }),
             onInputTextChanged = { /**/ },

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/CollectionScreen.kt
@@ -516,7 +516,7 @@ private fun Preview() {
             )
         )
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(
                 initialValue = initialState,

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/FilterDialog.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/FilterDialog.kt
@@ -128,7 +128,7 @@ data class FilterOption(
 @Composable
 @Preview
 private fun Preview() {
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             filters = listOf(
                 FilterOption(UserSeriesStatus.Current, true),

--- a/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/RatingDialog.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/collection/ui/RatingDialog.kt
@@ -99,7 +99,7 @@ private fun Render(
 @Composable
 @Preview
 private fun Preview() {
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             series = Series(
                 userId = 0,

--- a/features/series/src/main/java/com/chesire/nekome/app/series/item/ui/ItemScreen.kt
+++ b/features/series/src/main/java/com/chesire/nekome/app/series/item/ui/ItemScreen.kt
@@ -446,7 +446,7 @@ private fun Preview() {
         ),
         errorSnackbar = null
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(
                 initialValue = initialState,

--- a/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigScreen.kt
+++ b/features/settings/src/main/java/com/chesire/nekome/app/settings/config/ui/ConfigScreen.kt
@@ -433,7 +433,7 @@ private fun Preview() {
         showTitleLanguageDialog = false,
         rateSeriesValue = false
     )
-    NekomeTheme(isDarkTheme = true) {
+    NekomeTheme(theme = 2) {
         Render(
             state = produceState(
                 initialValue = initialState,


### PR DESCRIPTION
Aiming to close issue #734 

# What it does
Adds a Black theme to the themes menu. Also changes a parameter in the NekomeTheme composable.

# Potential oversights
Im unsure if there's a way to tell if the screen is AMOLED when setting a system theme, or if a black theme is something that android is supporting as a system theme right now. So i have not done anything in regards to setting Dynamic black or getting it set when its a system default

# Issues
## Readability
Currently, the way we get themes is a bit strange, relying on a pair containing 2 bools. While verbose it made it hard to adapt in its current state to include more themes.
I was looking at maybe using a Triple instead of a Pair, but i believe that may end up making things more confusing, especially when it comes to the logic of checking what theme is currently being used.
I wanted to opt for an Enum, but the enum class ...flags.Theme isn't accessible from ...Compose, so i ended up using the Enums value which isn't ideal but solves the problem immediately.
So currently when themes are checked & set within NekomeTheme it doesn't use an enum, and instead just goes through the when statement checking against ints.

## Colour choices
I assume that all that really needs to be changed for this theme is setting the background and surface colours to black? Not entirely sure what else would need to be changed.

## Visibility
In some weird case where you decide to log out whilst in Black mode, the Nekome logo will become completely unseeable. 

I added some kDoc to NekomeTheme to hopefully explain my reasoning a bit to anyone that would stumble across this in the future lol.

